### PR TITLE
runapp: Change it into a dev tool only loading and running an app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,23 @@
 .PHONY: all
-all: signerapp runapp mkdf-ssh-agent
+all: signerapp runapp tk1sign mkdf-ssh-agent
 
 .PHONY: signerapp
 signerapp:
 	$(MAKE) -C signerapp
 
-.PHONY: runapp
-runapp:
+runapp: ./cmd/runapp/*.go
 	go build ./cmd/runapp
 
-.PHONY: mkdf-ssh-agent
-mkdf-ssh-agent: signerapp
+tk1sign: signerapp ./cmd/tk1sign/*.go
+	go build ./cmd/tk1sign
+
+mkdf-ssh-agent: signerapp ./cmd/mkdf-ssh-agent/*.go
 	cp -af signerapp/app.bin cmd/mkdf-ssh-agent/app.bin
 	go build ./cmd/mkdf-ssh-agent
 
 .PHONY: clean
 clean:
-	rm -f runapp mkdf-ssh-agent cmd/mkdf-ssh-agent/app.bin
+	rm -f runapp tk1sign mkdf-ssh-agent cmd/mkdf-ssh-agent/app.bin
 	$(MAKE) -C signerapp clean
 
 .PHONY: update-mem-include

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ If your available `objcopy` is anything other than the default
 `llvm-objcopy-14`, then define `OBJCOPY` to whatever they're called on your
 system.
 
-The signerapp can be run both on the hardware Tillitis Key 1, and on a QEMU
-machine that emulates the platform. In both cases, the host program (`runapp`
-or `mkdf-ssh-agent` running on your computer) will talk to the app over a
-serial port, virtual or real. Please continue below in the suitable "Running
-apps on ..." section.
+The signerapp can be run both on the hardware Tillitis Key 1, and on a
+QEMU machine that emulates the platform. In both cases, the host
+program (`runapp`, `tk1sign` or `mkdf-ssh-agent` running on your
+computer) will talk to the app over a serial port, virtual or real.
+Please continue below in the suitable "Running apps on ..." section.
 
 ### Running apps on Tillitis Key 1
 
@@ -130,26 +130,47 @@ The MTA1 machine running on QEMU (which in turn runs the firmware, and
 then the app) can output some memory access (and other) logging. You can add
 `-d guest_errors` to the qemu commandline To make QEMU send these to stderr.
 
-## Using runapp
+## Using runsign and runapp
 
 By now you should have learned which serial port to use from one of the
-"Running on"-sections. If you're running on hardware, the LED on the device is
+"Running on" sections. If you're running on hardware, the LED on the device is
 expected to be flashing white, indicating that firmware is ready to receive an
 app to run.
 
-The host program `runapp` performs a complete, verbose signing. To run the
-program you need to specify both the serial port and the raw app binary that
+There's a script called `runsign` which loads and runs an ed25519
+signer app, then asks the app to sign a message and verifies it. You
+can use it like this:
+
+```
+./runsign.sh /dev/pts/19 file-with-message
+```
+
+The file with the message can currently be at most 4096 bytes long.
+
+The host program `runapp` only loads and starts an app. Then you will
+have to switch to a different program to speak your specific app
+protocol, for instance the `tk1sign` program provided here.
+
+To run `runapp` you need to specify both the serial port (unless
+you're using the default `/dev/ttyACM0`) and the raw app binary that
 should be run. The port used below is just an example.
 
 ```
 $ ./runapp --port /dev/pts/1 --file signerapp/app.bin
 ```
 
-If you're on hardware, the LED on the device is a steady green while the app
-is receiving data to sign. The LED then flashes green, indicating that you're
-required to touch the device for the signing to complete. The touch sensor is
-located next to the flashing LED -- touch and release. If running on QEMU, the
-virtual device is always touched automatically.
+`tk1sign` is used in a similar way:
+
+```
+./tk1sign --port /dev/pts/1 --file file-with-message-to-sign
+```
+
+If you're using real hardware, the LED on the device is a steady green
+while the app is receiving data to sign. The LED then flashes green,
+indicating that you're required to touch the device for the signing to
+complete. The touch sensor is located next to the flashing LED --
+touch and release. If running on QEMU, the virtual device is always
+touched automatically.
 
 The program should eventually output a signature and say that it was verified.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ refer to
 (in the tillitis-key1 repository) for instructions on initial programming of
 the device.
 
-#### Users on Linux users
+#### Users on Linux
 
 Running `lsusb` should list the device as `1207:8887 Tillitis MTA1-USB-V1`. On
 Linux, Tillitis Key 1's serial port path is typically `/dev/ttyACM0` (but it
@@ -73,8 +73,8 @@ terminal that you're working in.
 Your Tillitis Key 1 is now running the firmware. Its LED flashing white,
 indicating that it is ready to receive an app to run. You have also learned
 what serial port path to use for accessing it. You may need to pass this as
-`--port` when running the host programs. Continue in the section below, "Using
-runapp".
+`--port` when running the host programs. Continue in the section "Using
+runapp" below.
 
 #### Users on MacOS
 
@@ -87,9 +87,9 @@ ioreg -p IOUSB -w0 -l
 There should be an entry with `"USB Vendor Name" = "Tillitis"`.
 
 Looking in the `/dev` directory, there should be a device named like
-`/dev/tty.usbmodemXYZ`. Where XYZ is a number, for example 101. This is the
-device path that needs to be passed as `--port` when running the host programs.
-Continue in the section below, "Using runapp".
+`/dev/tty.usbmodemXYZ`. Where XYZ is a number, for example 101. This
+is the device path that needs to be passed as `--port` when running
+the host programs. Continue in the section "Using runsign..." below.
 
 ### Running apps on QEMU
 
@@ -122,9 +122,9 @@ $ <path-to-qemu>/build/qemu-system-riscv32 -nographic -M mta1_mkdf,fifo=chrid -b
        -chardev pty,id=chrid
 ```
 
-It tells you what serial port it is using, for instance `/dev/pts/1`. This is
-what you need to use as `--port` when running the host programs. Continue in
-the section below, "Using runapp".
+It tells you what serial port it is using, for instance `/dev/pts/1`.
+This is what you need to use as `--port` when running the host
+programs. Continue in the section "Using runsign..." below.
 
 The MTA1 machine running on QEMU (which in turn runs the firmware, and
 then the app) can output some memory access (and other) logging. You can add
@@ -137,7 +137,7 @@ By now you should have learned which serial port to use from one of the
 expected to be flashing white, indicating that firmware is ready to receive an
 app to run.
 
-There's a script called `runsign` which loads and runs an ed25519
+There's a script called `runsign.sh` which loads and runs an ed25519
 signer app, then asks the app to sign a message and verifies it. You
 can use it like this:
 

--- a/cmd/runapp/main.go
+++ b/cmd/runapp/main.go
@@ -13,10 +13,10 @@ import (
 )
 
 func main() {
-	fileName := pflag.String("file", "", "Name of file to be uploaded")
+	fileName := pflag.String("file", "", "App binary to be uploaded and started")
 	port := pflag.String("port", "/dev/ttyACM0", "Serial port path")
 	speed := pflag.Int("speed", 38400, "When talking over the serial port, bits per second")
-	verbose := pflag.Bool("verbose", false, "")
+	verbose := pflag.Bool("verbose", false, "Enable verbose output")
 
 	pflag.Parse()
 	if !*verbose {
@@ -24,8 +24,9 @@ func main() {
 	}
 
 	if *fileName == "" {
-		fmt.Printf("Usage: Please specify --file path-to-raw-binary\n")
-		os.Exit(1)
+		fmt.Printf("Please pass at least --file\n")
+		pflag.Usage()
+		os.Exit(2)
 	}
 
 	fmt.Printf("Connecting to device on serial port %s ...\n", *port)

--- a/cmd/runapp/main.go
+++ b/cmd/runapp/main.go
@@ -4,13 +4,11 @@
 package main
 
 import (
-	"crypto/ed25519"
 	"fmt"
 	"os"
 
 	"github.com/spf13/pflag"
 	"github.com/tillitis/tillitis-key1-apps/mkdf"
-	"github.com/tillitis/tillitis-key1-apps/mkdfsign"
 	"go.bug.st/serial"
 )
 
@@ -18,8 +16,17 @@ func main() {
 	fileName := pflag.String("file", "", "Name of file to be uploaded")
 	port := pflag.String("port", "/dev/ttyACM0", "Serial port path")
 	speed := pflag.Int("speed", 38400, "When talking over the serial port, bits per second")
+	verbose := pflag.Bool("verbose", false, "")
+
 	pflag.Parse()
-	// mkdf.SilenceLogging()
+	if !*verbose {
+		mkdf.SilenceLogging()
+	}
+
+	if *fileName == "" {
+		fmt.Printf("Usage: Please specify --file path-to-raw-binary\n")
+		os.Exit(1)
+	}
 
 	fmt.Printf("Connecting to device on serial port %s ...\n", *port)
 	conn, err := serial.Open(*port, &serial.Mode{BaudRate: *speed})
@@ -32,50 +39,20 @@ func main() {
 		os.Exit(code)
 	}
 
-	if *fileName != "" {
-		nameVer, err := mkdf.GetNameVersion(conn)
-		if err != nil {
-			fmt.Printf("GetNameVersion failed: %v\n", err)
-			fmt.Printf("If the serial port device is correct, then the device might not be in\n" +
-				"firmware-mode (and already have an app running). Please unplug and plug it in again.\n")
-			exit(1)
-		}
-		fmt.Printf("Firmware has name0:%s name1:%s version:%d\n",
-			nameVer.Name0, nameVer.Name1, nameVer.Version)
-		fmt.Printf("Loading app onto device\n")
-		err = mkdf.LoadAppFromFile(conn, *fileName)
-		if err != nil {
-			fmt.Printf("LoadAppFromFile failed: %v\n", err)
-			exit(1)
-		}
-	} else {
-		fmt.Printf("No app filename given, assuming app is already running\n")
-	}
-
-	pubkey, err := mkdfsign.GetPubkey(conn)
+	nameVer, err := mkdf.GetNameVersion(conn)
 	if err != nil {
-		fmt.Printf("GetPubKey failed: %v\n", err)
+		fmt.Printf("GetNameVersion failed: %v\n", err)
+		fmt.Printf("If the serial port device is correct, then the device might not be in\n" +
+			"firmware-mode (and already have an app running). Please unplug and plug it in again.\n")
 		exit(1)
 	}
-	fmt.Printf("Public Key from device: %x\n", pubkey)
-
-	var message []byte
-	for i := 0; i < 4096; i++ {
-		message = append(message, byte(i))
-	}
-
-	fmt.Printf("Message size: %v, message: %x\n", len(message), message)
-	signature, err := mkdfsign.Sign(conn, message)
+	fmt.Printf("Firmware has name0:%s name1:%s version:%d\n",
+		nameVer.Name0, nameVer.Name1, nameVer.Version)
+	fmt.Printf("Loading app from %v onto device\n", *fileName)
+	err = mkdf.LoadAppFromFile(conn, *fileName)
 	if err != nil {
-		fmt.Printf("Sign failed: %v\n", err)
+		fmt.Printf("LoadAppFromFile failed: %v\n", err)
 		exit(1)
-	}
-	fmt.Printf("Signature over message by device: %x\n", signature)
-
-	if !ed25519.Verify(pubkey, message, signature) {
-		fmt.Printf("Signature did NOT verify.\n")
-	} else {
-		fmt.Printf("Signature verified.\n")
 	}
 
 	exit(0)

--- a/cmd/tk1sign/main.go
+++ b/cmd/tk1sign/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	message, err := os.ReadFile(*fileName)
 	if err != nil {
-		fmt.Errorf("ReadFile: %w", err)
+		fmt.Printf("Could not read %s: %v\n", *fileName, err)
 		os.Exit(1)
 	}
 
@@ -37,12 +37,15 @@ func main() {
 		fmt.Printf("Could not open %s: %v\n", *port, err)
 		os.Exit(1)
 	}
-	defer conn.Close()
+	exit := func(code int) {
+		conn.Close()
+		os.Exit(code)
+	}
 
 	pubkey, err := mkdfsign.GetPubkey(conn)
 	if err != nil {
 		fmt.Printf("GetPubKey failed: %v\n", err)
-		os.Exit(1)
+		exit(1)
 	}
 	fmt.Printf("Public Key from device: %x\n", pubkey)
 
@@ -50,16 +53,16 @@ func main() {
 	signature, err := mkdfsign.Sign(conn, message)
 	if err != nil {
 		fmt.Printf("Sign failed: %v\n", err)
-		os.Exit(1)
+		exit(1)
 	}
 	fmt.Printf("Signature over message by device: %x\n", signature)
 
 	if !ed25519.Verify(pubkey, message, signature) {
 		fmt.Printf("Signature did NOT verify.\n")
-		os.Exit(1)
+		exit(1)
 	} else {
 		fmt.Printf("Signature verified.\n")
 	}
 
-	os.Exit(0)
+	exit(0)
 }

--- a/cmd/tk1sign/main.go
+++ b/cmd/tk1sign/main.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2022 - Tillitis AB
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+	"github.com/tillitis/tillitis-key1-apps/mkdf"
+	"github.com/tillitis/tillitis-key1-apps/mkdfsign"
+	"go.bug.st/serial"
+)
+
+func main() {
+	fileName := pflag.String("file", "", "Name of file with data to be signed")
+	port := pflag.String("port", "/dev/ttyACM0", "Serial port path")
+	speed := pflag.Int("speed", 38400, "When talking over the serial port, bits per second")
+	verbose := pflag.Bool("verbose", false, "")
+	pflag.Parse()
+
+	if !*verbose {
+		mkdf.SilenceLogging()
+	}
+
+	message, err := os.ReadFile(*fileName)
+	if err != nil {
+		fmt.Errorf("ReadFile: %w", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Connecting to device on serial port %s ...\n", *port)
+	conn, err := serial.Open(*port, &serial.Mode{BaudRate: *speed})
+	if err != nil {
+		fmt.Printf("Could not open %s: %v\n", *port, err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	pubkey, err := mkdfsign.GetPubkey(conn)
+	if err != nil {
+		fmt.Printf("GetPubKey failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Public Key from device: %x\n", pubkey)
+
+	fmt.Printf("Sending %v bytes of message\n", len(message))
+	signature, err := mkdfsign.Sign(conn, message)
+	if err != nil {
+		fmt.Printf("Sign failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Signature over message by device: %x\n", signature)
+
+	if !ed25519.Verify(pubkey, message, signature) {
+		fmt.Printf("Signature did NOT verify.\n")
+		os.Exit(1)
+	} else {
+		fmt.Printf("Signature verified.\n")
+	}
+
+	os.Exit(0)
+}

--- a/runsign.sh
+++ b/runsign.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+
+if [ $# -ne 2 ]
+then
+    echo runsign.sh port-device path-to-message
+    exit 1
+fi
+
+./runapp --port $1 --file signerapp/app.bin
+./tk1sign --port $1 --file $2
+


### PR DESCRIPTION
Joachim and I  wanted to make it easier to just load and run a device app without immediately trying to talk the app-specific protocol. This is nice in a development scenario.

Then you can start a new command to do the specific app stuff like, for instance, talking to the signerapp with its own protocol. I provide such a command in `tk1sign`.

To still have the same functionality as the old `runapp` I provide the `runsign.sh` shell script.
