### PR TITLE
Refactor Go protocol code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,2 @@
-[*.md]
+[*.{go,md}]
 max_line_length = 70

--- a/cmd/mkdf-ssh-agent/main.go
+++ b/cmd/mkdf-ssh-agent/main.go
@@ -65,7 +65,7 @@ func main() {
 		}
 	}
 
-	signer, err := NewMKDFSigner(devPath, speed)
+	signer, err := NewSigner(devPath, speed)
 	if err != nil {
 		if errors.Is(err, ErrMaybeWrongDevice) {
 			le.Printf("If the serial port is correct for the device, then it might not be it\n" +

--- a/cmd/mkdf-ssh-agent/main.go
+++ b/cmd/mkdf-ssh-agent/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"syscall"
 
 	"github.com/spf13/pflag"
@@ -81,6 +82,7 @@ func main() {
 		}
 		os.Exit(code)
 	}
+	handleSignals(func() { exit(1) }, os.Interrupt, syscall.SIGTERM)
 
 	agent := NewSSHAgent(signer)
 
@@ -112,4 +114,15 @@ func listPorts() error {
 		fmt.Printf("%s\n", port)
 	}
 	return nil
+}
+
+func handleSignals(action func(), sig ...os.Signal) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, sig...)
+	go func() {
+		for {
+			<-ch
+			action()
+		}
+	}()
 }

--- a/cmd/mkdf-ssh-agent/mkdfsigner.go
+++ b/cmd/mkdf-ssh-agent/mkdfsigner.go
@@ -35,8 +35,7 @@ type MKDFSigner struct {
 }
 
 func NewMKDFSigner(devPath string, speed int) (*MKDFSigner, error) {
-	// TODO keep
-	// mkdf.SilenceLogging()
+	mkdf.SilenceLogging()
 	le.Printf("Connecting to device on serial port %s ...\n", devPath)
 	tk, err := mkdf.New(devPath, speed)
 	if err != nil {

--- a/cmd/runapp/main.go
+++ b/cmd/runapp/main.go
@@ -36,7 +36,9 @@ func main() {
 		os.Exit(1)
 	}
 	exit := func(code int) {
-		tk.Close()
+		if err := tk.Close(); err != nil {
+			fmt.Printf("Close: %v\n", err)
+		}
 		os.Exit(code)
 	}
 

--- a/cmd/runapp/main.go
+++ b/cmd/runapp/main.go
@@ -6,6 +6,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/pflag"
 	"github.com/tillitis/tillitis-key1-apps/mkdf"
@@ -41,6 +43,7 @@ func main() {
 		}
 		os.Exit(code)
 	}
+	handleSignals(func() { exit(1) }, os.Interrupt, syscall.SIGTERM)
 
 	nameVer, err := tk.GetNameVersion()
 	if err != nil {
@@ -59,4 +62,15 @@ func main() {
 	}
 
 	exit(0)
+}
+
+func handleSignals(action func(), sig ...os.Signal) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, sig...)
+	go func() {
+		for {
+			<-ch
+			action()
+		}
+	}()
 }

--- a/cmd/runapp/main.go
+++ b/cmd/runapp/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/tillitis/tillitis-key1-apps/mkdf"
-	"go.bug.st/serial"
 )
 
 func main() {
@@ -30,17 +29,18 @@ func main() {
 	}
 
 	fmt.Printf("Connecting to device on serial port %s ...\n", *port)
-	conn, err := serial.Open(*port, &serial.Mode{BaudRate: *speed})
+
+	tk, err := mkdf.New(*port, *speed)
 	if err != nil {
 		fmt.Printf("Could not open %s: %v\n", *port, err)
 		os.Exit(1)
 	}
 	exit := func(code int) {
-		conn.Close()
+		tk.Close()
 		os.Exit(code)
 	}
 
-	nameVer, err := mkdf.GetNameVersion(conn)
+	nameVer, err := tk.GetNameVersion()
 	if err != nil {
 		fmt.Printf("GetNameVersion failed: %v\n", err)
 		fmt.Printf("If the serial port device is correct, then the device might not be in\n" +
@@ -50,7 +50,7 @@ func main() {
 	fmt.Printf("Firmware has name0:%s name1:%s version:%d\n",
 		nameVer.Name0, nameVer.Name1, nameVer.Version)
 	fmt.Printf("Loading app from %v onto device\n", *fileName)
-	err = mkdf.LoadAppFromFile(conn, *fileName)
+	err = tk.LoadAppFromFile(*fileName)
 	if err != nil {
 		fmt.Printf("LoadAppFromFile failed: %v\n", err)
 		exit(1)

--- a/cmd/tk1sign/main.go
+++ b/cmd/tk1sign/main.go
@@ -7,6 +7,8 @@ import (
 	"crypto/ed25519"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/pflag"
 	"github.com/tillitis/tillitis-key1-apps/mkdf"
@@ -44,6 +46,7 @@ func main() {
 		}
 		os.Exit(code)
 	}
+	handleSignals(func() { exit(1) }, os.Interrupt, syscall.SIGTERM)
 
 	pubkey, err := signer.GetPubkey()
 	if err != nil {
@@ -69,4 +72,15 @@ func main() {
 	}
 
 	exit(0)
+}
+
+func handleSignals(action func(), sig ...os.Signal) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, sig...)
+	go func() {
+		for {
+			<-ch
+			action()
+		}
+	}()
 }

--- a/cmd/tk1sign/main.go
+++ b/cmd/tk1sign/main.go
@@ -33,13 +33,15 @@ func main() {
 	fmt.Printf("Connecting to device on serial port %s ...\n", *port)
 	tk, err := mkdf.New(*port, *speed)
 	if err != nil {
-		fmt.Printf("Couldn't open...\n")
+		fmt.Printf("Could not open %s: %v\n", *port, err)
 		os.Exit(1)
 	}
 
 	signer := mkdfsign.New(tk)
 	exit := func(code int) {
-		signer.Close()
+		if err := signer.Close(); err != nil {
+			fmt.Printf("%v\n", err)
+		}
 		os.Exit(code)
 	}
 

--- a/mkdf/mkdf.go
+++ b/mkdf/mkdf.go
@@ -75,18 +75,16 @@ func (tk TillitisKey) Close() error {
 	return nil
 }
 
-// SetReadTimeout sets the timeout of the underlying serial connection
-// to the TK1. Pass 0 seconds for no timeout.
+// SetReadTimeout sets the timeout of the underlying serial connection to the
+// TK1. Pass 0 seconds to not have any timeout. Note that the timeout
+// implemented in the serial lib only works for simple Read(). E.g.
+// io.ReadFull() will Read() until the buffer is full.
 func (tk TillitisKey) SetReadTimeout(seconds int) error {
-	le.Printf("settimeout: %d", seconds)
 	var t time.Duration = -1
 	if seconds > 0 {
-		// This sets `seconds` seconds timeout, see:
-		// https://github.com/bugst/go-serial/issues/141
-		t = 2_000 / 100 * time.Millisecond
+		t = time.Duration(seconds) * time.Second
 	}
-	err := tk.conn.SetReadTimeout(t)
-	if err != nil {
+	if err := tk.conn.SetReadTimeout(t); err != nil {
 		return fmt.Errorf("SetReadTimeout: %w", err)
 	}
 	return nil

--- a/mkdf/mkdf.go
+++ b/mkdf/mkdf.go
@@ -68,16 +68,24 @@ func New(port string, speed int) (TillitisKey, error) {
 }
 
 // Close the connection to the TK1
-func (tk TillitisKey) Close() {
-	tk.conn.Close()
+func (tk TillitisKey) Close() error {
+	if err := tk.conn.Close(); err != nil {
+		return fmt.Errorf("conn.Close: %w", err)
+	}
+	return nil
 }
 
 // SetReadTimeout sets the timeout of the underlying serial connection
 // to the TK1. Pass 0 seconds for no timeout.
 func (tk TillitisKey) SetReadTimeout(seconds int) error {
-	// This sets `seconds` seconds timeout, see:
-	// https://github.com/bugst/go-serial/issues/141
-	err := tk.conn.SetReadTimeout(time.Duration(seconds*1_000/100) * time.Millisecond)
+	le.Printf("settimeout: %d", seconds)
+	var t time.Duration = -1
+	if seconds > 0 {
+		// This sets `seconds` seconds timeout, see:
+		// https://github.com/bugst/go-serial/issues/141
+		t = 2_000 / 100 * time.Millisecond
+	}
+	err := tk.conn.SetReadTimeout(t)
 	if err != nil {
 		return fmt.Errorf("SetReadTimeout: %w", err)
 	}

--- a/mkdf/mkdf.go
+++ b/mkdf/mkdf.go
@@ -1,6 +1,27 @@
 // Copyright (C) 2022 - Tillitis AB
 // SPDX-License-Identifier: GPL-2.0-only
 
+// Package mkdf provides a connection to a Tillitis Key 1 security stick.
+// To create a new connection:
+//
+//	tk, err := mkdf.New(*port, *speed)
+//
+// Then you can start using it by asking it to identify itself:
+//
+//	nameVer, err := tk.GetNameVersion()
+//
+// Or uploading and starting an app on the stick:
+//
+//	err = tk.LoadAppFromFile(*fileName)
+//
+// After this, you will have to switch to a new protocol specific to
+// the app, see for instance the package
+// github.com/tillitis/tillitis-key1-apps/mkdfsign for one such app
+// specific protocol.
+//
+// When writing your app specific protocol you might still want to use
+// the framing protocol provided here. See GenFrameBuf() and
+// ReadFrame().
 package mkdf
 
 import (
@@ -26,6 +47,39 @@ const (
 	StatusBad = 0x01
 )
 
+const NoTimeout time.Duration = -1 // No timeout for serial connection
+
+// TillitisKey is a serial connection to a Tillitis Key 1 and the
+// commands that the firmware supports.
+type TillitisKey struct {
+	conn serial.Port
+}
+
+// New() opens a connection to the Tillitis Key 1 at the serial device
+// port at indicated speed.
+func New(port string, speed int) (TillitisKey, error) {
+	var tk TillitisKey
+	var err error
+
+	tk.conn, err = serial.Open(port, &serial.Mode{BaudRate: speed})
+	if err != nil {
+		return tk, fmt.Errorf("Could not open %s: %v\n", port, err)
+	}
+
+	return tk, nil
+}
+
+// Close the connection to the TK1
+func (tk TillitisKey) Close() {
+	tk.conn.Close()
+}
+
+// SetReadTimeout sets the timeout of the underlying serial connection
+// to the TK1.
+func (tk TillitisKey) SetReadTimeout(timeout time.Duration) error {
+	return tk.conn.SetReadTimeout(timeout)
+}
+
 type NameVersion struct {
 	Name0   string
 	Name1   string
@@ -38,54 +92,60 @@ func (n *NameVersion) Unpack(raw []byte) {
 	n.Version = binary.LittleEndian.Uint32(raw[8:12])
 }
 
-func GetNameVersion(conn serial.Port) (*NameVersion, error) {
-	hdr := Frame{
-		ID:       2,
-		Endpoint: DestFW,
-		CmdLen:   CmdLen1,
+// GetNameVersion() gets the name and version from the TK1 firmware
+func (tk TillitisKey) GetNameVersion() (*NameVersion, error) {
+	tx, err := GenFrameBuf(2, DestFW, CmdLen1)
+	if err != nil {
+		return nil, err
 	}
 
 	// This sets 2s timeout, see: https://github.com/bugst/go-serial/issues/141
-	err := conn.SetReadTimeout(2_000 / 100 * time.Millisecond)
+	//err = tk.SetReadTimeout(2_000 / 100 * time.Millisecond)
 	if err != nil {
 		return nil, fmt.Errorf("SetReadTimeout: %w", err)
 	}
 
-	tx, err := packSimple(hdr, fwCmdGetNameVersion)
-	if err != nil {
-		return nil, fmt.Errorf("packSimple: %w", err)
-	}
+	// Set command code
+	tx[1] = byte(cmdGetNameVersion)
 
 	Dump("GetNameVersion tx", tx)
-	if err = Xmit(conn, tx); err != nil {
+	if err = tk.Write(tx); err != nil {
 		return nil, fmt.Errorf("Xmit: %w", err)
 	}
 
-	rx, err := fwRecv(conn, fwRspGetNameVersion, hdr.ID, CmdLen32)
+	_, rx, err := tk.ReadFrame(CmdLen32, DestFW)
 	if err != nil {
-		return nil, fmt.Errorf("fwRecv: %w", err)
+		return nil, fmt.Errorf("read frame: %w", err)
 	}
 
-	err = conn.SetReadTimeout(serial.NoTimeout)
+	if rx[0] != byte(rspGetNameVersion) {
+		return nil, fmt.Errorf("")
+	}
+
+	err = tk.conn.SetReadTimeout(serial.NoTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("SetReadTimeout: %w", err)
 	}
 
 	nameVer := &NameVersion{}
-	nameVer.Unpack(rx)
+	nameVer.Unpack(rx[1:])
 
 	return nameVer, nil
 }
 
-func LoadAppFromFile(conn serial.Port, fileName string) error {
+// LoadAppFromFile() loads and runs a raw binary file from fileName into the TK1
+func (tk TillitisKey) LoadAppFromFile(fileName string) error {
 	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return fmt.Errorf("ReadFile: %w", err)
 	}
-	return LoadApp(conn, content)
+
+	return tk.LoadApp(content)
 }
 
-func LoadApp(conn serial.Port, bin []byte) error {
+// LoadApp loads the contents of bin into the TK1 and runs it after
+// verifying that the digest is the same
+func (tk TillitisKey) LoadApp(bin []byte) error {
 	binLen := len(bin)
 	if binLen > 65536 {
 		return fmt.Errorf("File to big")
@@ -93,7 +153,7 @@ func LoadApp(conn serial.Port, bin []byte) error {
 
 	le.Printf("app size: %v, 0x%x, 0b%b\n", binLen, binLen, binLen)
 
-	err := setAppSize(conn, binLen)
+	err := tk.setAppSize(binLen)
 	if err != nil {
 		return err
 	}
@@ -101,7 +161,7 @@ func LoadApp(conn serial.Port, bin []byte) error {
 	// Load the file
 	var offset int
 	for nsent := 0; offset < binLen; offset += nsent {
-		nsent, err = loadAppData(conn, bin[offset:])
+		nsent, err = tk.loadAppData(bin[offset:])
 		if err != nil {
 			return fmt.Errorf("loadAppData: %w", err)
 		}
@@ -111,7 +171,7 @@ func LoadApp(conn serial.Port, bin []byte) error {
 	}
 
 	le.Printf("Going to getappdigest\n")
-	appDigest, err := getAppDigest(conn)
+	appDigest, err := tk.getAppDigest()
 	if err != nil {
 		return err
 	}
@@ -130,130 +190,143 @@ func LoadApp(conn serial.Port, bin []byte) error {
 
 	// Run the app
 	le.Printf("Running the app\n")
-	return runApp(conn)
+	return tk.runApp()
+
+	return nil
 }
 
-func setAppSize(conn serial.Port, size int) error {
-	appsize := appSize{
-		hdr: Frame{
-			ID:       2,
-			Endpoint: DestFW,
-			CmdLen:   CmdLen32,
-		},
-		size: size,
-	}
-
-	tx, err := appsize.pack()
+// setAppSize() sets the size of the app to be loaded into the TK1.
+func (tk TillitisKey) setAppSize(size int) error {
+	tx, err := GenFrameBuf(2, DestFW, CmdLen32)
 	if err != nil {
 		return err
 	}
 
+	// Set command code
+	tx[1] = byte(cmdLoadAppSize)
+
+	// Set size
+	tx[2] = byte(size)
+	tx[3] = byte(size >> 8)
+	tx[4] = byte(size >> 16)
+	tx[5] = byte(size >> 24)
+
 	Dump("SetAppSize tx", tx)
-	if err = Xmit(conn, tx); err != nil {
+	if err = tk.Write(tx); err != nil {
 		return fmt.Errorf("Xmit: %w", err)
 	}
 
-	rx, err := fwRecv(conn, fwRspLoadAppSize, appsize.hdr.ID, CmdLen4)
-	if err != nil {
-		return fmt.Errorf("fwRecv: %w", err)
+	_, rx, err := tk.ReadFrame(CmdLen4, DestFW)
+
+	if rx[0] != byte(rspLoadAppSize) {
+		return fmt.Errorf("Expected fwRspLoadAppSize, got 0x%x", rx[0])
 	}
-	if rx[0] != StatusOK {
+	if rx[1] != StatusOK {
 		return fmt.Errorf("SetAppSize NOK")
 	}
 
 	return nil
 }
 
-func loadAppData(conn serial.Port, content []byte) (int, error) {
-	cmdLen := CmdLen128
-	appdata := appData{
-		hdr: Frame{
-			ID:       2,
-			Endpoint: DestFW,
-			CmdLen:   cmdLen,
-		},
-		// Payload len is cmdlen minus the fw cmd byte
-		data: make([]byte, cmdLen.Bytelen()-1),
-	}
-
-	nsent := appdata.copy(content)
-
-	tx, err := appdata.pack()
+// loadAppData() loads a chunk of the raw app binary into the TK1 and
+// waits for a reply.
+func (tk TillitisKey) loadAppData(content []byte) (int, error) {
+	tx, err := GenFrameBuf(2, DestFW, CmdLen128)
 	if err != nil {
 		return 0, err
 	}
 
+	tx[1] = byte(cmdLoadAppData)
+
+	payload := make([]byte, CmdLen128.Bytelen()-1)
+	copied := copy(payload, content)
+
+	// Add padding if not filling the payload buffer.
+	if copied < len(payload) {
+		padding := make([]byte, len(payload)-copied)
+		copy(payload[copied:], padding)
+	}
+
+	copy(tx[2:], payload)
+
 	Dump("LoadAppData tx", tx)
-	if err = Xmit(conn, tx); err != nil {
-		return 0, fmt.Errorf("Xmit: %w", err)
+
+	if err = tk.Write(tx); err != nil {
+		return 0, fmt.Errorf("Write: %w", err)
 	}
 
 	// Wait for reply
-	rx, err := fwRecv(conn, fwRspLoadAppData, appdata.hdr.ID, CmdLen4)
+	_, rx, err := tk.ReadFrame(CmdLen4, DestFW)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("read frame: %w", err)
 	}
 
-	if rx[0] != StatusOK {
+	if rx[0] != byte(rspLoadAppData) {
+		return 0, fmt.Errorf("Expected fwRspLoadAppData, got %v", rx[0])
+	}
+
+	if rx[1] != StatusOK {
 		return 0, fmt.Errorf("LoadAppData NOK")
 	}
 
-	return nsent, nil
+	return copied, nil
 }
 
-func getAppDigest(conn serial.Port) ([32]byte, error) {
+// getAppDigest() asks for an app digest from the TK1.
+func (tk TillitisKey) getAppDigest() ([32]byte, error) {
 	var md [32]byte
 
-	hdr := Frame{
-		ID:       2,
-		Endpoint: DestFW,
-		CmdLen:   CmdLen1,
-	}
-
-	// Check the digest
-	tx, err := packSimple(hdr, fwCmdGetAppDigest)
-	if err != nil {
-		return md, fmt.Errorf("packSimple: %w", err)
-	}
-
-	Dump("GetDigest tx", tx)
-	if err = Xmit(conn, tx); err != nil {
-		return md, fmt.Errorf("Xmit: %w", err)
-	}
-
-	rx, err := fwRecv(conn, fwRspGetAppDigest, hdr.ID, CmdLen128)
+	tx, err := GenFrameBuf(2, DestFW, CmdLen1)
 	if err != nil {
 		return md, err
 	}
 
-	copy(md[:], rx)
+	tx[1] = byte(cmdGetAppDigest)
+	Dump("GetDigest tx", tx)
+
+	if err = tk.Write(tx); err != nil {
+		return md, fmt.Errorf("Write: %w", err)
+	}
+
+	// Wait for reply
+	_, rx, err := tk.ReadFrame(CmdLen128, DestFW)
+	if err != nil {
+		return md, fmt.Errorf("read frame: %w", err)
+	}
+
+	if rx[0] != byte(rspGetAppDigest) {
+		return md, fmt.Errorf("Expected fwRspGetAppDigest, got %v", rx[0])
+	}
+
+	copy(md[:], rx[1:])
 
 	return md, nil
 }
 
-func runApp(conn serial.Port) error {
-	hdr := Frame{
-		ID:       2,
-		Endpoint: DestFW,
-		CmdLen:   CmdLen1,
-	}
-
-	tx, err := packSimple(hdr, fwCmdRunApp)
-	if err != nil {
-		return fmt.Errorf("packSimple: %w", err)
-	}
-
-	Dump("RunApp tx", tx)
-	if err = Xmit(conn, tx); err != nil {
-		return fmt.Errorf("Xmit: %w", err)
-	}
-
-	rx, err := fwRecv(conn, fwRspRunApp, hdr.ID, CmdLen4)
+// runApp() runs the loaded app, if any, in the TK1.
+func (tk TillitisKey) runApp() error {
+	tx, err := GenFrameBuf(2, DestFW, CmdLen1)
 	if err != nil {
 		return err
 	}
 
-	if rx[0] != StatusOK {
+	tx[1] = byte(cmdRunApp)
+
+	if err = tk.Write(tx); err != nil {
+		return fmt.Errorf("Write: %w", err)
+	}
+
+	// Wait for reply
+	_, rx, err := tk.ReadFrame(CmdLen4, DestFW)
+	if err != nil {
+		return fmt.Errorf("read frame: %w", err)
+	}
+
+	if rx[0] != byte(rspRunApp) {
+		return fmt.Errorf("Expected fwRspRunApp, got %v", rx[0])
+	}
+
+	if rx[1] != StatusOK {
 		return fmt.Errorf("RunApp NOK")
 	}
 

--- a/mkdf/proto.go
+++ b/mkdf/proto.go
@@ -4,18 +4,14 @@
 package mkdf
 
 import (
-	"bufio"
 	"encoding/hex"
 	"fmt"
 	"io"
-
-	"go.bug.st/serial"
 )
 
 type Endpoint byte
 
 const (
-	// destIFPGA endpoint = 0
 	// destAFPGA endpoint = 1
 	DestFW  Endpoint = 2
 	DestApp Endpoint = 3
@@ -31,6 +27,8 @@ const (
 	CmdLen128 CmdLen = 3
 )
 
+// Bytelen returns the number of bytes corresponding to the specific
+// CmdLen value.
 func (l CmdLen) Bytelen() int {
 	switch l {
 	case CmdLen1:
@@ -48,48 +46,48 @@ func (l CmdLen) Bytelen() int {
 type fwCmd byte
 
 const (
-	fwCmdGetNameVersion fwCmd = 0x01
-	fwRspGetNameVersion fwCmd = 0x02
-	fwCmdLoadAppSize    fwCmd = 0x03
-	fwRspLoadAppSize    fwCmd = 0x04
-	fwCmdLoadAppData    fwCmd = 0x05
-	fwRspLoadAppData    fwCmd = 0x06
-	fwCmdRunApp         fwCmd = 0x07
-	fwRspRunApp         fwCmd = 0x08
-	fwCmdGetAppDigest   fwCmd = 0x09
-	fwRspGetAppDigest   fwCmd = 0x10
+	cmdGetNameVersion fwCmd = 0x01
+	rspGetNameVersion fwCmd = 0x02
+	cmdLoadAppSize    fwCmd = 0x03
+	rspLoadAppSize    fwCmd = 0x04
+	cmdLoadAppData    fwCmd = 0x05
+	rspLoadAppData    fwCmd = 0x06
+	cmdRunApp         fwCmd = 0x07
+	rspRunApp         fwCmd = 0x08
+	cmdGetAppDigest   fwCmd = 0x09
+	rspGetAppDigest   fwCmd = 0x10
 )
 
 func (f fwCmd) String() string {
 	switch f {
-	case fwCmdGetNameVersion:
+	case cmdGetNameVersion:
 		return "fwCmdGetNameVersion"
 
-	case fwRspGetNameVersion:
+	case rspGetNameVersion:
 		return "fwRspGetNameVersion"
 
-	case fwCmdLoadAppSize:
+	case cmdLoadAppSize:
 		return "fwCmdLoadAppSize"
 
-	case fwRspLoadAppSize:
+	case rspLoadAppSize:
 		return "fwRspLoadAppSize"
 
-	case fwCmdLoadAppData:
+	case cmdLoadAppData:
 		return "fwCmdLoadAppData"
 
-	case fwRspLoadAppData:
+	case rspLoadAppData:
 		return "fwRspLoadAppData"
 
-	case fwCmdRunApp:
+	case cmdRunApp:
 		return "fwCmdRunApp"
 
-	case fwRspRunApp:
+	case rspRunApp:
 		return "fwRspRunApp"
 
-	case fwCmdGetAppDigest:
+	case cmdGetAppDigest:
 		return "fwCmdGetAppDigest"
 
-	case fwRspGetAppDigest:
+	case rspGetAppDigest:
 		return "fwRspGetAppDigest"
 
 	default:
@@ -97,27 +95,45 @@ func (f fwCmd) String() string {
 	}
 }
 
-type Frame struct {
-	ID       byte
+type FramingHdr struct {
+	Id       byte
 	Endpoint Endpoint
 	CmdLen   CmdLen
 }
 
-// Calculate len in bytes of a complete frame, including header byte and cmdlen
-// bytes.
-func (f *Frame) FrameLen() int {
-	// Could try f.Pack() first to ensure valid
+// FrameLen returns lenght in bytes of a complete frame, including
+// header byte and cmdlen bytes.
+func (f *FramingHdr) FrameLen() int {
+	// XXX Could try GenframeBuf() first to ensure valid
 	return 1 + f.CmdLen.Bytelen()
 }
 
-// # Pack the frame header byte
+func parseframe(b byte) (FramingHdr, error) {
+	var f FramingHdr
+
+	if b&0x80 != 0 {
+		return f, fmt.Errorf("bad version")
+	}
+	if b&0x4 != 0 {
+		return f, fmt.Errorf("must be zero")
+	}
+
+	f.Id = byte((uint32(b) & 0x60) >> 5)
+	f.Endpoint = Endpoint((b & 0x18) >> 3)
+	f.CmdLen = CmdLen(b & 0x3)
+
+	return f, nil
+}
+
+// GenFrameBuf() generates a framing protocol header and allocates a
+// buffer with the appropriate size for the command.
 //
+// Header:
 // Bit [7] (1 bit). Reserved - possible protocol version.
 // Bits [6..5] (2 bits). Frame ID tag.
 //
 // Bits [4..3] (2 bits). Endpoint number.
 //
-//	HW in interface_fpga
 //	HW in application_fpga
 //	FW in application_fpga
 //	SW (application) in application_fpga
@@ -134,116 +150,29 @@ func (f *Frame) FrameLen() int {
 // does **not** include the command header byte. This means that a complete
 // command frame, with a header indicating a data length of 128 bytes, is 129
 // bytes in length.
-func (f *Frame) Pack() (byte, error) {
-	if f.ID > 3 {
-		return 0, fmt.Errorf("bad id")
+func GenFrameBuf(id byte, endpoint Endpoint, cmdlen CmdLen) ([]byte, error) {
+	if id > 3 {
+		return nil, fmt.Errorf("bad id")
 	}
-	if f.Endpoint > 3 {
-		return 0, fmt.Errorf("bad endpoint")
+	if endpoint > 3 {
+		return nil, fmt.Errorf("bad endpoint")
 	}
-	if f.CmdLen > 3 {
-		return 0, fmt.Errorf("bad cmdlen")
-	}
-
-	hdr := (f.ID << 5) | (byte(f.Endpoint) << 3) | byte(f.CmdLen)
-
-	return hdr, nil
-}
-
-func (f *Frame) Unpack(b byte) error {
-	if b&0x80 != 0 {
-		return fmt.Errorf("bad version")
-	}
-	if b&0x4 != 0 {
-		return fmt.Errorf("must be zero")
+	if cmdlen > 3 {
+		return nil, fmt.Errorf("bad cmdlen")
 	}
 
-	f.ID = byte((uint32(b) & 0x60) >> 5)
-	f.Endpoint = Endpoint((b & 0x18) >> 3)
-	f.CmdLen = CmdLen(b & 0x3)
-
-	return nil
-}
-
-// Pack a simple command with no corresponding struct.
-func packSimple(hdr Frame, cmd fwCmd) ([]byte, error) {
-	var err error
-
-	tx := make([]byte, hdr.FrameLen())
-
-	// Frame header
-	tx[0], err = hdr.Pack()
-	if err != nil {
-		return nil, err
-	}
-
-	tx[1] = byte(cmd)
+	// Make a buffer with frame header + cmdLen payload
+	tx := make([]byte, 1+cmdlen.Bytelen())
+	tx[0] = (id << 5) | (byte(endpoint) << 3) | byte(cmdlen)
 
 	return tx, nil
 }
 
-type appSize struct {
-	hdr  Frame
-	size int
-}
-
-func (a *appSize) pack() ([]byte, error) {
-	tx := make([]byte, a.hdr.FrameLen())
-	var err error
-
-	// Frame header
-	tx[0], err = a.hdr.Pack()
-	if err != nil {
-		return nil, err
-	}
-
-	// Append command code
-	tx[1] = byte(fwCmdLoadAppSize)
-
-	// Append size
-	tx[2] = byte(a.size)
-	tx[3] = byte(a.size >> 8)
-	tx[4] = byte(a.size >> 16)
-	tx[5] = byte(a.size >> 24)
-
-	return tx, nil
-}
-
-type appData struct {
-	hdr  Frame
-	data []byte
-}
-
-func (a *appData) copy(content []byte) int {
-	copied := copy(a.data, content)
-	// Add padding if not filling the payload buf.
-	if copied < len(a.data) {
-		padding := make([]byte, len(a.data)-copied)
-		copy(a.data[copied:], padding)
-	}
-	return copied
-}
-
-func (a *appData) pack() ([]byte, error) {
-	tx := make([]byte, a.hdr.FrameLen())
-	var err error
-
-	// Frame header
-	tx[0], err = a.hdr.Pack()
-	if err != nil {
-		return nil, err
-	}
-
-	tx[1] = byte(fwCmdLoadAppData)
-
-	copy(tx[2:], a.data)
-
-	return tx, nil
-}
-
+// Dump() hexdumps data in d with an explaining string s first. It
+// assumes the data in d corresponds to the framing protocol header
+// and firmware data.
 func Dump(s string, d []byte) {
-	var hdr Frame
-	err := hdr.Unpack(d[0])
+	hdr, err := parseframe(d[0])
 	if err != nil {
 		le.Printf("%s (header Unpack error: %s):\n%s", s, err, hex.Dump(d))
 		return
@@ -251,71 +180,41 @@ func Dump(s string, d []byte) {
 	le.Printf("%s (FrameLen: 1+%d):\n%s", s, hdr.CmdLen.Bytelen(), hex.Dump(d))
 }
 
-func Xmit(conn serial.Port, d []byte) error {
-	b := bufio.NewWriter(conn)
-	if _, err := b.Write(d); err != nil {
-		return fmt.Errorf("Write: %w", err)
+func (tk TillitisKey) Write(d []byte) error {
+	_, err := tk.conn.Write(d)
+	if err != nil {
+		return err
 	}
-	if err := b.Flush(); err != nil {
-		return fmt.Errorf("Flush: %w", err)
-	}
+
 	return nil
 }
 
-func fwRecv(conn serial.Port, expectedRsp fwCmd, id byte, expectedLen CmdLen) ([]byte, error) {
-	// Blocking
-	rx, err := Recv(conn)
+// ReadFrame() reads a response in the framing protocol . of expected
+// length len and endpoint as in expectedDest. It returns the payload
+// without the framing protocol header.
+func (tk TillitisKey) ReadFrame(len CmdLen, expectedDest Endpoint) (FramingHdr, []byte, error) {
+	var hdr FramingHdr
+
+	// Create a buffer covering frame header + firmware payload
+	rx := make([]byte, 1+len.Bytelen())
+
+	_, err := io.ReadFull(tk.conn, rx)
 	if err != nil {
-		return nil, err
+		return hdr, nil, fmt.Errorf("ReadFull: %w", err)
 	}
 
-	Dump(" rx", rx)
-
-	var hdr Frame
-
-	err = hdr.Unpack(rx[0])
+	hdr, err = parseframe(rx[0])
 	if err != nil {
-		return nil, fmt.Errorf("Unpack: %w", err)
+		return hdr, nil, fmt.Errorf("Couldn't parse framing header: %w", err)
 	}
 
-	rsp := fwCmd(rx[1])
-	le.Printf("FW code: %v\n", rsp)
-	if rsp != expectedRsp {
-		return nil, fmt.Errorf("incorrect response code %v != expected %v", rsp, expectedRsp)
+	if hdr.CmdLen != len {
+		return hdr, nil, fmt.Errorf("Framing: Expected len %v, got %v", len, hdr.CmdLen)
 	}
 
-	if hdr.CmdLen != expectedLen {
-		return nil, fmt.Errorf("incorrect length %v != expected %v", hdr.CmdLen, expectedLen)
+	if hdr.Endpoint != expectedDest {
+		return hdr, nil, fmt.Errorf("Message not meant for us: dest %v", hdr.Endpoint)
 	}
 
-	if hdr.ID != id {
-		return nil, fmt.Errorf("incorrect id %v != expected %v", hdr.ID, id)
-	}
-
-	// 0 is frame header
-	// 1 is fw header
-	// Return the rest
-	return rx[2:], nil
-}
-
-func Recv(conn serial.Port) ([]byte, error) {
-	r := bufio.NewReader(conn)
-	b, err := r.Peek(1)
-	if err != nil {
-		return nil, fmt.Errorf("Peek: %w", err)
-	}
-	var hdr Frame
-
-	err = hdr.Unpack(b[0])
-	if err != nil {
-		return nil, fmt.Errorf("Unpack: %w", err)
-	}
-
-	rx := make([]byte, hdr.FrameLen())
-	_, err = io.ReadFull(r, rx)
-	if err != nil {
-		return nil, fmt.Errorf("ReadFull: %w", err)
-	}
-
-	return rx, nil
+	return hdr, rx[1:], nil
 }

--- a/mkdf/proto.go
+++ b/mkdf/proto.go
@@ -52,41 +52,21 @@ type Cmd interface {
 }
 
 var (
-	cmdGetNameVersion = fwCmd{
-		code: 0x01, cmdLen: CmdLen1, str: "cmdGetNameVersion",
-	}
-	rspGetNameVersion = fwCmd{
-		code: 0x02, cmdLen: CmdLen32, str: "rspGetNameVersion",
-	}
-	cmdLoadAppSize = fwCmd{
-		code: 0x03, cmdLen: CmdLen32, str: "cmdLoadAppSize",
-	}
-	rspLoadAppSize = fwCmd{
-		code: 0x04, cmdLen: CmdLen4, str: "rspLoadAppSize",
-	}
-	cmdLoadAppData = fwCmd{
-		code: 0x05, cmdLen: CmdLen128, str: "cmdLoadAppData",
-	}
-	rspLoadAppData = fwCmd{
-		code: 0x06, cmdLen: CmdLen4, str: "rspLoadAppData",
-	}
-	cmdRunApp = fwCmd{
-		code: 0x07, cmdLen: CmdLen1, str: "cmdRunApp",
-	}
-	rspRunApp = fwCmd{
-		code: 0x08, cmdLen: CmdLen4, str: "rspRunApp",
-	}
-	cmdGetAppDigest = fwCmd{
-		code: 0x09, cmdLen: CmdLen1, str: "cmdGetAppDigest",
-	}
-	rspGetAppDigest = fwCmd{
-		code: 0x10, cmdLen: CmdLen128, str: "rspGetAppDigest",
-	}
+	cmdGetNameVersion = fwCmd{0x01, "cmdGetNameVersion", CmdLen1}
+	rspGetNameVersion = fwCmd{0x02, "rspGetNameVersion", CmdLen32}
+	cmdLoadAppSize    = fwCmd{0x03, "cmdLoadAppSize", CmdLen32}
+	rspLoadAppSize    = fwCmd{0x04, "rspLoadAppSize", CmdLen4}
+	cmdLoadAppData    = fwCmd{0x05, "cmdLoadAppData", CmdLen128}
+	rspLoadAppData    = fwCmd{0x06, "rspLoadAppData", CmdLen4}
+	cmdRunApp         = fwCmd{0x07, "cmdRunApp", CmdLen1}
+	rspRunApp         = fwCmd{0x08, "rspRunApp", CmdLen4}
+	cmdGetAppDigest   = fwCmd{0x09, "cmdGetAppDigest", CmdLen1}
+	rspGetAppDigest   = fwCmd{0x10, "rspGetAppDigest", CmdLen128}
 )
 
 type fwCmd struct {
 	code   byte
-	str    string
+	name   string
 	cmdLen CmdLen
 }
 
@@ -103,7 +83,7 @@ func (c fwCmd) Endpoint() Endpoint {
 }
 
 func (c fwCmd) String() string {
-	return c.str
+	return c.name
 }
 
 type FramingHdr struct {

--- a/mkdf/proto.go
+++ b/mkdf/proto.go
@@ -112,13 +112,6 @@ type FramingHdr struct {
 	CmdLen   CmdLen
 }
 
-// FrameLen returns length in bytes of a complete frame, including
-// header byte and cmdlen bytes.
-func (f *FramingHdr) FrameLen() int {
-	// XXX Could try GenframeBuf() first to ensure valid
-	return 1 + f.CmdLen.Bytelen()
-}
-
 func parseframe(b byte) (FramingHdr, error) {
 	var f FramingHdr
 

--- a/mkdf/proto.go
+++ b/mkdf/proto.go
@@ -61,34 +61,34 @@ const (
 func (f fwCmd) String() string {
 	switch f {
 	case cmdGetNameVersion:
-		return "fwCmdGetNameVersion"
+		return "cmdGetNameVersion"
 
 	case rspGetNameVersion:
-		return "fwRspGetNameVersion"
+		return "rspGetNameVersion"
 
 	case cmdLoadAppSize:
-		return "fwCmdLoadAppSize"
+		return "cmdLoadAppSize"
 
 	case rspLoadAppSize:
-		return "fwRspLoadAppSize"
+		return "rspLoadAppSize"
 
 	case cmdLoadAppData:
-		return "fwCmdLoadAppData"
+		return "cmdLoadAppData"
 
 	case rspLoadAppData:
-		return "fwRspLoadAppData"
+		return "rspLoadAppData"
 
 	case cmdRunApp:
-		return "fwCmdRunApp"
+		return "cmdRunApp"
 
 	case rspRunApp:
-		return "fwRspRunApp"
+		return "rspRunApp"
 
 	case cmdGetAppDigest:
-		return "fwCmdGetAppDigest"
+		return "cmdGetAppDigest"
 
 	case rspGetAppDigest:
-		return "fwRspGetAppDigest"
+		return "rspGetAppDigest"
 
 	default:
 		return "Unknown FW code"
@@ -96,12 +96,12 @@ func (f fwCmd) String() string {
 }
 
 type FramingHdr struct {
-	Id       byte
+	ID       byte
 	Endpoint Endpoint
 	CmdLen   CmdLen
 }
 
-// FrameLen returns lenght in bytes of a complete frame, including
+// FrameLen returns length in bytes of a complete frame, including
 // header byte and cmdlen bytes.
 func (f *FramingHdr) FrameLen() int {
 	// XXX Could try GenframeBuf() first to ensure valid
@@ -118,7 +118,7 @@ func parseframe(b byte) (FramingHdr, error) {
 		return f, fmt.Errorf("must be zero")
 	}
 
-	f.Id = byte((uint32(b) & 0x60) >> 5)
+	f.ID = byte((uint32(b) & 0x60) >> 5)
 	f.Endpoint = Endpoint((b & 0x18) >> 3)
 	f.CmdLen = CmdLen(b & 0x3)
 
@@ -183,15 +183,15 @@ func Dump(s string, d []byte) {
 func (tk TillitisKey) Write(d []byte) error {
 	_, err := tk.conn.Write(d)
 	if err != nil {
-		return err
+		return fmt.Errorf("Write: %w", err)
 	}
 
 	return nil
 }
 
-// ReadFrame() reads a response in the framing protocol . of expected
-// length len and endpoint as in expectedDest. It returns the payload
-// without the framing protocol header.
+// ReadFrame() reads a response in the framing protocol of expected
+// length len and endpoint as in expectedDest. It returns the framing
+// protocol header, payload, and any error separately.
 func (tk TillitisKey) ReadFrame(len CmdLen, expectedDest Endpoint) (FramingHdr, []byte, error) {
 	var hdr FramingHdr
 

--- a/mkdfsign/mkdfsign.go
+++ b/mkdfsign/mkdfsign.go
@@ -1,6 +1,21 @@
 // Copyright (C) 2022 - Tillitis AB
 // SPDX-License-Identifier: GPL-2.0-only
 
+// Packade mkdfsign provides a connection the the ed25519 signerapp
+// running on the Tillitis Key 1. You're expected to pass an existing
+// TK1 connection to it, so use it like this:
+//
+//   tk, err := mkdf.New(*port, *speed)
+//   signer := mkdfsign.New(tk)
+//
+// Then use it like this to get the public key of the TK1:
+//
+//   pubkey, err := signer.GetPubkey()
+//
+// And like this to sign a message:
+//
+//   signature, err := signer.Sign(message)
+//
 package mkdfsign
 
 import (
@@ -8,7 +23,6 @@ import (
 	"time"
 
 	"github.com/tillitis/tillitis-key1-apps/mkdf"
-	"go.bug.st/serial"
 )
 
 type appCmd byte
@@ -17,98 +31,110 @@ type appCmd byte
 // protocol does). The cmd code is used as response code, if it was successful.
 // Separate response codes for errors could be added though.
 const (
-	appCmdGetPubkey      appCmd = 0x01
-	appCmdSetSize        appCmd = 0x02
-	appCmdSignData       appCmd = 0x03
-	appCmdGetSig         appCmd = 0x04
-	appCmdGetNameVersion appCmd = 0x05
+	cmdGetPubkey      appCmd = 0x01
+	cmdSetSize        appCmd = 0x02
+	cmdSignData       appCmd = 0x03
+	cmdGetSig         appCmd = 0x04
+	cmdGetNameVersion appCmd = 0x05
 )
 
-func GetAppNameVersion(conn serial.Port) (*mkdf.NameVersion, error) {
-	hdr := mkdf.Frame{
-		ID:       2,
-		Endpoint: mkdf.DestApp,
-		CmdLen:   mkdf.CmdLen1,
-	}
+type Signer struct {
+	tk mkdf.TillitisKey // A connection to a Tillitis Key 1
+}
 
+// New() gets you a connection to a ed25519 signerapp running on the
+// Tillitis Key 1. You're expected to pass an existing TK1 connection
+// to it, so use it like this:
+//   tk, err := mkdf.New(port, speed)
+//   signer := mkdfsign.New(tk)
+func New(tk mkdf.TillitisKey) Signer {
+	var signer Signer
+
+	signer.tk = tk
+
+	return signer
+}
+
+// Close closes the connection to the TK1
+func (s Signer) Close() {
+	s.tk.Close()
+}
+
+// GetAppNameVersion gets the name and version of the running app in
+// the same style as the stick itself.
+func (s Signer) GetAppNameVersion() (*mkdf.NameVersion, error) {
 	// This sets 2s timeout, see: https://github.com/bugst/go-serial/issues/141
-	err := conn.SetReadTimeout(2_000 / 100 * time.Millisecond)
+	err := s.tk.SetReadTimeout(2_000 / 100 * time.Millisecond)
 	if err != nil {
 		return nil, fmt.Errorf("SetReadTimeout: %w", err)
 	}
 
-	tx := make([]byte, hdr.FrameLen())
-
-	// Frame header
-	tx[0], err = hdr.Pack()
-	if err != nil {
-		return nil, fmt.Errorf("Pack: %w", err)
-	}
-	tx[1] = byte(appCmdGetNameVersion)
+	tx, err := mkdf.GenFrameBuf(2, mkdf.DestApp, mkdf.CmdLen1)
+	// Set command code
+	tx[1] = byte(cmdGetNameVersion)
 
 	mkdf.Dump("GetAppNameVersion tx", tx)
-	if err = mkdf.Xmit(conn, tx); err != nil {
-		return nil, fmt.Errorf("Xmit: %w", err)
+	if err = s.tk.Write(tx); err != nil {
+		return nil, fmt.Errorf("Write: %w", err)
 	}
 
-	rx, err := appRecv(conn, appCmd(tx[1]), hdr.ID, mkdf.CmdLen32)
+	_, rx, err := s.tk.ReadFrame(mkdf.CmdLen32, mkdf.DestApp)
 	if err != nil {
-		return nil, fmt.Errorf("appRecv: %w", err)
+		return nil, fmt.Errorf("read frame: %w", err)
 	}
 
-	err = conn.SetReadTimeout(serial.NoTimeout)
+	if rx[0] != byte(cmdGetNameVersion) {
+		return nil, fmt.Errorf("")
+	}
+
+	err = s.tk.SetReadTimeout(mkdf.NoTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("SetReadTimeout: %w", err)
 	}
 
 	nameVer := &mkdf.NameVersion{}
-	// Skip frame header & app header
-	nameVer.Unpack(rx[2:])
+	nameVer.Unpack(rx[1:])
 
 	return nameVer, nil
 }
 
-func GetPubkey(conn serial.Port) ([]byte, error) {
-	hdr := mkdf.Frame{
-		ID:       2,
-		Endpoint: mkdf.DestApp,
-		CmdLen:   mkdf.CmdLen1,
-	}
+// GetPubkey fetches the public key of the signer.
+func (s Signer) GetPubkey() ([]byte, error) {
+	tx, err := mkdf.GenFrameBuf(2, mkdf.DestApp, mkdf.CmdLen1)
 
-	var err error
-
-	tx := make([]byte, hdr.FrameLen())
-
-	// Frame header
-	tx[0], err = hdr.Pack()
-	if err != nil {
-		return nil, fmt.Errorf("Pack: %w", err)
-	}
-	tx[1] = byte(appCmdGetPubkey)
+	// Set command code
+	tx[1] = byte(cmdGetPubkey)
 
 	mkdf.Dump("GetPubkey tx", tx)
-	if err = mkdf.Xmit(conn, tx); err != nil {
-		return nil, fmt.Errorf("Xmit: %w", err)
+	if err = s.tk.Write(tx); err != nil {
+		return nil, fmt.Errorf("Write: %w", err)
 	}
 
-	rx, err := appRecv(conn, appCmd(tx[1]), hdr.ID, mkdf.CmdLen128)
+	_, rx, err := s.tk.ReadFrame(mkdf.CmdLen128, mkdf.DestApp)
 	if err != nil {
-		return nil, fmt.Errorf("appRecv: %w", err)
+		return nil, fmt.Errorf("read frame: %w", err)
+	}
+
+	mkdf.Dump("GetPubKey rx", rx)
+
+	if rx[0] != byte(cmdGetPubkey) {
+		return nil, fmt.Errorf("Expected appCmdGetPubkey, got %v", rx[0])
 	}
 
 	// Skip frame header & app header, returning size of ed25519 pubkey
-	return rx[2 : 2+32], nil
+	return rx[1 : 1+32], nil
 }
 
-func Sign(conn serial.Port, data []byte) ([]byte, error) {
-	err := signSetSize(conn, len(data))
+// Sign signs the message in data and returns an ed25519 signature.
+func (s Signer) Sign(data []byte) ([]byte, error) {
+	err := s.setSize(len(data))
 	if err != nil {
-		return nil, fmt.Errorf("signSetSize: %w", err)
+		return nil, fmt.Errorf("SetSize: %w", err)
 	}
 
 	var offset int
 	for nsent := 0; offset < len(data); offset += nsent {
-		nsent, err = signLoad(conn, data[offset:])
+		nsent, err = s.signLoad(data[offset:])
 		if err != nil {
 			return nil, fmt.Errorf("signLoad: %w", err)
 		}
@@ -117,7 +143,7 @@ func Sign(conn serial.Port, data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("transmitted more than expected")
 	}
 
-	signature, err := getSig(conn)
+	signature, err := s.getSig()
 	if err != nil {
 		return nil, fmt.Errorf("getSig: %w", err)
 	}
@@ -125,192 +151,104 @@ func Sign(conn serial.Port, data []byte) ([]byte, error) {
 	return signature, nil
 }
 
-type signSize struct {
-	hdr  mkdf.Frame
-	size int
-}
+// SetSize sets the size of the data to sign.
+func (s Signer) setSize(size int) error {
+	tx, err := mkdf.GenFrameBuf(2, mkdf.DestApp, mkdf.CmdLen32)
 
-func (a *signSize) pack() ([]byte, error) {
-	tx := make([]byte, a.hdr.FrameLen())
-	var err error
+	// Set command code
+	tx[1] = byte(cmdSetSize)
 
-	// Frame header
-	tx[0], err = a.hdr.Pack()
-	if err != nil {
-		return nil, fmt.Errorf("Pack: %w", err)
-	}
-
-	// Append command code
-	tx[1] = byte(appCmdSetSize)
-
-	// Append size
-	tx[2] = byte(a.size)
-	tx[3] = byte(a.size >> 8)
-	tx[4] = byte(a.size >> 16)
-	tx[5] = byte(a.size >> 24)
-
-	return tx, nil
-}
-
-func signSetSize(conn serial.Port, size int) error {
-	signsize := signSize{
-		hdr: mkdf.Frame{
-			ID:       2,
-			Endpoint: mkdf.DestApp,
-			CmdLen:   mkdf.CmdLen32,
-		},
-		size: size,
-	}
-
-	tx, err := signsize.pack()
-	if err != nil {
-		return err
-	}
-
-	mkdf.Dump("SignSetSize tx", tx)
-	if err = mkdf.Xmit(conn, tx); err != nil {
+	// Set size
+	tx[2] = byte(size)
+	tx[3] = byte(size >> 8)
+	tx[4] = byte(size >> 16)
+	tx[5] = byte(size >> 24)
+	mkdf.Dump("SetAppSize tx", tx)
+	if err = s.tk.Write(tx); err != nil {
 		return fmt.Errorf("Xmit: %w", err)
 	}
 
-	rx, err := appRecv(conn, appCmd(tx[1]), signsize.hdr.ID, mkdf.CmdLen4)
-	if err != nil {
-		return fmt.Errorf("appRecv: %w", err)
+	_, rx, err := s.tk.ReadFrame(mkdf.CmdLen4, mkdf.DestApp)
+
+	mkdf.Dump("SetAppSize rx", rx)
+	if rx[0] != byte(cmdSetSize) {
+		return fmt.Errorf("Expected appCmdSetSize, got 0x%x", rx[0])
 	}
 
-	if rx[2] != mkdf.StatusOK {
-		return fmt.Errorf("signSetSize NOK (%d)", rx[2])
+	if rx[1] != mkdf.StatusOK {
+		return fmt.Errorf("SetSignSize NOK")
 	}
 
 	return nil
 }
 
-type signData struct {
-	hdr  mkdf.Frame
-	data []byte
-}
-
-func (a *signData) copy(content []byte) int {
-	copied := copy(a.data, content)
-	// Add padding if not filling the payload buf.
-	if copied < len(a.data) {
-		padding := make([]byte, len(a.data)-copied)
-		copy(a.data[copied:], padding)
-	}
-	return copied
-}
-
-func (a *signData) pack() ([]byte, error) {
-	tx := make([]byte, a.hdr.FrameLen())
-	var err error
-
-	// Frame header
-	tx[0], err = a.hdr.Pack()
-	if err != nil {
-		return nil, fmt.Errorf("Pack: %w", err)
-	}
-
-	tx[1] = byte(appCmdSignData)
-
-	copy(tx[2:], a.data)
-
-	return tx, nil
-}
-
-func signLoad(conn serial.Port, data []byte) (int, error) {
-	cmdLen := mkdf.CmdLen128
-	signdata := signData{
-		hdr: mkdf.Frame{
-			ID:       2,
-			Endpoint: mkdf.DestApp,
-			CmdLen:   cmdLen,
-		},
-		// Payload len is cmdlen minus the app cmd byte
-		data: make([]byte, cmdLen.Bytelen()-1),
-	}
-
-	nsent := signdata.copy(data)
-
-	tx, err := signdata.pack()
+// signload loads a chunk of a message to sign and waits for a
+// response from the signer.
+func (s Signer) signLoad(content []byte) (int, error) {
+	tx, err := mkdf.GenFrameBuf(2, mkdf.DestApp, mkdf.CmdLen128)
 	if err != nil {
 		return 0, err
 	}
 
-	mkdf.Dump("SignData tx", tx)
-	if err = mkdf.Xmit(conn, tx); err != nil {
-		return 0, fmt.Errorf("Xmit: %w", err)
+	// Set the command
+	tx[1] = byte(cmdSignData)
+
+	payload := make([]byte, mkdf.CmdLen128.Bytelen()-1)
+	copied := copy(payload, content)
+
+	// Add padding if not filling the payload buffer.
+	if copied < len(payload) {
+		padding := make([]byte, len(payload)-copied)
+		copy(payload[copied:], padding)
 	}
 
-	rx, err := appRecv(conn, appCmd(tx[1]), signdata.hdr.ID, mkdf.CmdLen4)
+	copy(tx[2:], payload)
+
+	mkdf.Dump("LoadSignData tx", tx)
+
+	if err = s.tk.Write(tx); err != nil {
+		return 0, fmt.Errorf("Write: %w", err)
+	}
+
+	// Wait for reply
+	_, rx, err := s.tk.ReadFrame(mkdf.CmdLen4, mkdf.DestApp)
 	if err != nil {
-		return 0, fmt.Errorf("appRecv: %w", err)
+		return 0, fmt.Errorf("read frame: %w", err)
 	}
 
-	if rx[2] != mkdf.StatusOK {
-		return 0, fmt.Errorf("signData NOK (%d)", rx[2])
+	if rx[0] != byte(cmdSignData) {
+		return 0, fmt.Errorf("Expected appCmdSignData, got %v", rx[0])
 	}
 
-	return nsent, nil
+	if rx[1] != mkdf.StatusOK {
+		return 0, fmt.Errorf("SignData NOK")
+	}
+
+	return copied, nil
 }
 
-func getSig(conn serial.Port) ([]byte, error) {
-	hdr := mkdf.Frame{
-		ID:       2,
-		Endpoint: mkdf.DestApp,
-		CmdLen:   mkdf.CmdLen1,
+// getSig gets the ed25519 signature from the signer app, if
+// available.
+func (s Signer) getSig() ([]byte, error) {
+	tx, err := mkdf.GenFrameBuf(2, mkdf.DestApp, mkdf.CmdLen1)
+
+	// Set command code
+	tx[1] = byte(cmdGetSig)
+
+	mkdf.Dump("getSig tx", tx)
+	if err = s.tk.Write(tx); err != nil {
+		return nil, fmt.Errorf("Write: %w", err)
 	}
 
-	var err error
-
-	tx := make([]byte, hdr.FrameLen())
-
-	// Frame header
-	tx[0], err = hdr.Pack()
+	_, rx, err := s.tk.ReadFrame(mkdf.CmdLen128, mkdf.DestApp)
 	if err != nil {
-		return nil, fmt.Errorf("Pack: %w", err)
-	}
-	tx[1] = byte(appCmdGetSig)
-
-	mkdf.Dump("GetSig tx", tx)
-	if err = mkdf.Xmit(conn, tx); err != nil {
-		return nil, fmt.Errorf("Xmit: %w", err)
+		return nil, fmt.Errorf("read frame: %w", err)
 	}
 
-	rx, err := appRecv(conn, appCmd(tx[1]), hdr.ID, mkdf.CmdLen128)
-	if err != nil {
-		return nil, fmt.Errorf("appRecv: %w", err)
+	if rx[0] != byte(cmdGetSig) {
+		return nil, fmt.Errorf("Expected appCmdGetSig, got %v", rx[0])
 	}
 
-	// Skip frame header & app header, returning size of ed25519 signature
-	return rx[2 : 2+64], nil
-}
-
-func appRecv(conn serial.Port, expectedRsp appCmd, id byte, expectedLen mkdf.CmdLen) ([]byte, error) {
-	rx, err := mkdf.Recv(conn)
-	if err != nil {
-		return nil, fmt.Errorf("Recv: %w", err)
-	}
-
-	mkdf.Dump(" rx", rx)
-
-	var hdr mkdf.Frame
-
-	err = hdr.Unpack(rx[0])
-	if err != nil {
-		return nil, fmt.Errorf("Unpack: %w", err)
-	}
-
-	rsp := appCmd(rx[1])
-	if rsp != expectedRsp {
-		return nil, fmt.Errorf("incorrect response code %v != expected %v", rsp, expectedRsp)
-	}
-
-	if hdr.CmdLen != expectedLen {
-		return nil, fmt.Errorf("incorrect length %v != expected %v", hdr.CmdLen, expectedLen)
-	}
-
-	if hdr.ID != id {
-		return nil, fmt.Errorf("incorrect id %v != expected %v", hdr.ID, id)
-	}
-
-	return rx, nil
+	// Skip app header, returning size of ed25519 signature
+	return rx[1 : 1+64], nil
 }

--- a/mkdfsign/mkdfsign.go
+++ b/mkdfsign/mkdfsign.go
@@ -24,41 +24,21 @@ import (
 )
 
 var (
-	cmdGetPubkey appCmd = appCmd{
-		code: 0x01, cmdLen: mkdf.CmdLen1, str: "cmdGetPubkey",
-	}
-	rspGetPubkey appCmd = appCmd{
-		code: 0x02, cmdLen: mkdf.CmdLen128, str: "rspGetPubkey",
-	}
-	cmdSetSize appCmd = appCmd{
-		code: 0x03, cmdLen: mkdf.CmdLen32, str: "cmdSetSize",
-	}
-	rspSetSize appCmd = appCmd{
-		code: 0x04, cmdLen: mkdf.CmdLen4, str: "rspSetSize",
-	}
-	cmdSignData appCmd = appCmd{
-		code: 0x05, cmdLen: mkdf.CmdLen128, str: "cmdSignData",
-	}
-	rspSignData appCmd = appCmd{
-		code: 0x06, cmdLen: mkdf.CmdLen4, str: "rspSignData",
-	}
-	cmdGetSig appCmd = appCmd{
-		code: 0x07, cmdLen: mkdf.CmdLen1, str: "cmdGetSig",
-	}
-	rspGetSig appCmd = appCmd{
-		code: 0x08, cmdLen: mkdf.CmdLen128, str: "rspGetSig",
-	}
-	cmdGetNameVersion appCmd = appCmd{
-		code: 0x09, cmdLen: mkdf.CmdLen1, str: "cmdGetNameVersion",
-	}
-	rspGetNameVersion appCmd = appCmd{
-		code: 0x0a, cmdLen: mkdf.CmdLen32, str: "rspGetNameVersion",
-	}
+	cmdGetPubkey      = appCmd{0x01, "cmdGetPubkey", mkdf.CmdLen1}
+	rspGetPubkey      = appCmd{0x02, "rspGetPubkey", mkdf.CmdLen128}
+	cmdSetSize        = appCmd{0x03, "cmdSetSize", mkdf.CmdLen32}
+	rspSetSize        = appCmd{0x04, "rspSetSize", mkdf.CmdLen4}
+	cmdSignData       = appCmd{0x05, "cmdSignData", mkdf.CmdLen128}
+	rspSignData       = appCmd{0x06, "rspSignData", mkdf.CmdLen4}
+	cmdGetSig         = appCmd{0x07, "cmdGetSig", mkdf.CmdLen1}
+	rspGetSig         = appCmd{0x08, "rspGetSig", mkdf.CmdLen128}
+	cmdGetNameVersion = appCmd{0x09, "cmdGetNameVersion", mkdf.CmdLen1}
+	rspGetNameVersion = appCmd{0x0a, "rspGetNameVersion", mkdf.CmdLen32}
 )
 
 type appCmd struct {
 	code   byte
-	str    string
+	name   string
 	cmdLen mkdf.CmdLen
 }
 
@@ -75,7 +55,7 @@ func (c appCmd) Endpoint() mkdf.Endpoint {
 }
 
 func (c appCmd) String() string {
-	return c.str
+	return c.name
 }
 
 type Signer struct {

--- a/mkdfsign/mkdfsign.go
+++ b/mkdfsign/mkdfsign.go
@@ -55,8 +55,11 @@ func New(tk mkdf.TillitisKey) Signer {
 }
 
 // Close closes the connection to the TK1
-func (s Signer) Close() {
-	s.tk.Close()
+func (s Signer) Close() error {
+	if err := s.tk.Close(); err != nil {
+		return fmt.Errorf("tk.Close: %w", err)
+	}
+	return nil
 }
 
 // GetAppNameVersion gets the name and version of the running app in

--- a/signerapp/app_proto.c
+++ b/signerapp/app_proto.c
@@ -10,27 +10,27 @@ void appreply(struct frame_header hdr, enum appcmd rspcode, void *buf)
 	enum cmdlen len;
 
 	switch (rspcode) {
-	case APP_CMD_GET_PUBKEY:
+	case APP_RSP_GET_PUBKEY:
 		len = LEN_128;
 		nbytes = 128;
 		break;
 
-	case APP_CMD_SET_SIZE:
+	case APP_RSP_SET_SIZE:
 		len = LEN_4;
 		nbytes = 4;
 		break;
 
-	case APP_CMD_SIGN_DATA:
+	case APP_RSP_SIGN_DATA:
 		len = LEN_4;
 		nbytes = 4;
 		break;
 
-	case APP_CMD_GET_SIG:
+	case APP_RSP_GET_SIG:
 		len = LEN_128;
 		nbytes = 128;
 		break;
 
-	case APP_CMD_GET_NAMEVERSION:
+	case APP_RSP_GET_NAMEVERSION:
 		len = LEN_32;
 		nbytes = 32;
 		break;

--- a/signerapp/app_proto.h
+++ b/signerapp/app_proto.h
@@ -7,15 +7,22 @@
 #include "../common/lib.h"
 #include "../common/proto.h"
 
+// clang-format off
 enum appcmd {
-	APP_CMD_GET_PUBKEY = 0x01,
-	APP_CMD_SET_SIZE = 0x02,
-	APP_CMD_SIGN_DATA = 0x03,
-	APP_CMD_GET_SIG = 0x04,
-	APP_CMD_GET_NAMEVERSION = 0x05,
+	APP_CMD_GET_PUBKEY      = 0x01,
+	APP_RSP_GET_PUBKEY      = 0x02,
+	APP_CMD_SET_SIZE        = 0x03,
+	APP_RSP_SET_SIZE        = 0x04,
+	APP_CMD_SIGN_DATA       = 0x05,
+	APP_RSP_SIGN_DATA       = 0x06,
+	APP_CMD_GET_SIG         = 0x07,
+	APP_RSP_GET_SIG         = 0x08,
+	APP_CMD_GET_NAMEVERSION = 0x09,
+	APP_RSP_GET_NAMEVERSION = 0x0a,
 
-	APP_RSP_UNKNOWN_CMD = 0xff
+	APP_RSP_UNKNOWN_CMD     = 0xff,
 };
+// clang-format on
 
 void appreply(struct frame_header hdr, enum appcmd rspcode, void *buf);
 

--- a/signerapp/main.c
+++ b/signerapp/main.c
@@ -105,7 +105,7 @@ int main(void)
 		case APP_CMD_GET_PUBKEY:
 			puts("APP_CMD_GET_PUBKEY\n");
 			memcpy(rsp, pubkey, 32);
-			appreply(hdr, APP_CMD_GET_PUBKEY, rsp);
+			appreply(hdr, APP_RSP_GET_PUBKEY, rsp);
 			break;
 
 		case APP_CMD_SET_SIZE:
@@ -123,7 +123,7 @@ int main(void)
 			if (message_size > MAX_SIGN_SIZE) {
 				puts("Message too big!\n");
 				rsp[0] = STATUS_BAD;
-				appreply(hdr, APP_CMD_SET_SIZE, rsp);
+				appreply(hdr, APP_RSP_SET_SIZE, rsp);
 				break;
 			}
 
@@ -132,7 +132,7 @@ int main(void)
 			msg_idx = 0;
 
 			rsp[0] = STATUS_OK;
-			appreply(hdr, APP_CMD_SET_SIZE, rsp);
+			appreply(hdr, APP_RSP_SET_SIZE, rsp);
 			led_steady = LED_GREEN;
 			break;
 
@@ -144,7 +144,7 @@ int main(void)
 			// not been called
 			if (hdr.len != cmdBytelen || message_size == 0) {
 				rsp[0] = STATUS_BAD;
-				appreply(hdr, APP_CMD_SIGN_DATA, rsp);
+				appreply(hdr, APP_RSP_SIGN_DATA, rsp);
 				break;
 			}
 
@@ -170,7 +170,7 @@ int main(void)
 			}
 
 			rsp[0] = STATUS_OK;
-			appreply(hdr, APP_CMD_SIGN_DATA, rsp);
+			appreply(hdr, APP_RSP_SIGN_DATA, rsp);
 			led_steady = LED_GREEN;
 			break;
 
@@ -178,11 +178,11 @@ int main(void)
 			puts("APP_CMD_GET_SIG\n");
 			if (signature_done == 0) {
 				rsp[0] = STATUS_BAD;
-				appreply(hdr, APP_CMD_GET_SIG, rsp);
+				appreply(hdr, APP_RSP_GET_SIG, rsp);
 				break;
 			}
 			memcpy(rsp, signature, 64);
-			appreply(hdr, APP_CMD_GET_SIG, rsp);
+			appreply(hdr, APP_RSP_GET_SIG, rsp);
 			led_steady = LED_GREEN;
 			break;
 
@@ -194,7 +194,7 @@ int main(void)
 				memcpy(rsp + 4, app_name1, 4);
 				memcpy(rsp + 8, &app_version, 4);
 			}
-			appreply(hdr, APP_CMD_GET_NAMEVERSION, rsp);
+			appreply(hdr, APP_RSP_GET_NAMEVERSION, rsp);
 			break;
 
 		default:


### PR DESCRIPTION
Make the protocol code more idiomatic with mkdf.New() and mkdfsign.New() and methods on the resulting type.

Skip most of extra structs and Unpack() and Pack() functions.

No more peek() and no more extra bufio.Reader.

Added lots of documentation. See godoc in mkdf and mkdfsign for how to use.

The ssh-agent is still untouched and doesn't build right now. Probably doesn't need a lot of changes.