### PR TITLE
WIP Implement USS

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - test
     - unused
   disable:
+    - nestif
     - cyclop
     - funlen
     - exhaustruct  # TODO? annoying for now

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ firmware when loading the app. By adding the flag `--uss`, you will be
 asked to type a phrase which will be hashed to become the USS digest
 (the final newline is removed from the phrase before hashing).
 
+Alternatively, you may use `--uss-file=filename` to make it read the
+contents of a file, which is then hashed as the USS. The filename can
+be `-` for reading from stdin. Note that all data in file/stdin is
+read and hashed without any modification.
+
 The USS digest is used by the firmware, together with other material,
 for deriving secrets for the application. The practical result for
 signerapp is that the ed25519 public/private keys will change
@@ -238,11 +243,8 @@ by https://go-review.googlesource.com/c/crypto/+/412154/ (until then
 it's also not possible to implement the upcoming SSH agent
 restrictions https://www.openssh.com/agent-restrict.html).)
 
-The mkdf-ssh-agent also supports the `--uss` flag, as described for
-`runapp` above. In addition, `--uss-file=filename` makes it read the
-contents of a file, which is then hashed as the USS. The filename can
-be `-` for reading from stdin. Note that all data in file/stdin is
-read and hashed without any modification.
+The mkdf-ssh-agent also supports the `--uss` and `--uss-file` flags,
+as described for `runapp` above.
 
 You can use `-k` (long option: `--show-pubkey`) to only output the
 pubkey. The pubkey is printed to stdout for easy redirection, but some

--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ should be run. The port used below is just an example.
 $ ./runapp --port /dev/pts/1 --file signerapp/app.bin
 ```
 
+The `runapp` also supports sending a User Supplied Secret (USS) to the
+firmware when loading the app. By adding the flag `--uss`, you will be
+asked to type a phrase which will be hashed to become the USS digest
+(the final newline is removed from the phrase before hashing).
+
+The USS digest is used by the firmware, together with other material,
+for deriving secrets for the application. The practical result for
+signerapp is that the ed25519 public/private keys will change
+depending on what USS (phrase) you entered. To learn more, read the
+[system_description.md](https://github.com/tillitis/tillitis-key1/blob/main/doc/system_description/system_description.md)
+(in the tillitis-key1 repository).
+
 `tk1sign` is used in a similar way:
 
 ```
@@ -219,20 +231,22 @@ $ SSH_AUTH_SOCK=/path/to/agent.sock ssh -F /dev/null localhost
 `-F /dev/null` is used to ignore your ~/.ssh/config which could
 interfere with this test.
 
-The message `agent 27: ssh: parse error in message type 27` coming
+(The message `agent 27: ssh: parse error in message type 27` coming
 from mkdf-ssh-agent is due to
 https://github.com/golang/go/issues/51689 and will eventually be fixed
 by https://go-review.googlesource.com/c/crypto/+/412154/ (until then
 it's also not possible to implement the upcoming SSH agent
-restrictions https://www.openssh.com/agent-restrict.html).
+restrictions https://www.openssh.com/agent-restrict.html).)
+
+The mkdf-ssh-agent also supports the `--uss` flag, as described for
+`runapp` above. In addition, `--uss-file=filename` makes it read the
+contents of a file, which is then hashed as the USS. The filename can
+be `-` for reading from stdin. Note that all data in file/stdin is
+read and hashed without any modification.
 
 You can use `-k` (long option: `--show-pubkey`) to only output the
-pubkey (on stdout, some message are still present on stderr), which
-can be useful:
-
-```
-$ ./mkdf-ssh-agent -k --port /dev/pts/1
-```
+pubkey. The pubkey is printed to stdout for easy redirection, but some
+messages are still present on stderr.
 
 # fooapp
 

--- a/cmd/mkdf-ssh-agent/signer.go
+++ b/cmd/mkdf-ssh-agent/signer.go
@@ -4,15 +4,20 @@
 package main
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ed25519"
 	_ "embed"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/tillitis/tillitis-key1-apps/mkdf"
 	"github.com/tillitis/tillitis-key1-apps/mkdfsign"
+	"golang.org/x/term"
 )
 
 var ErrMaybeWrongDevice = errors.New("wrong device or non-responsive app")
@@ -29,55 +34,97 @@ const (
 )
 
 type Signer struct {
-	*mkdf.TillitisKey
-	*mkdfsign.Signer
+	tk         *mkdf.TillitisKey
+	mkdfSigner *mkdfsign.Signer
 }
 
-func NewSigner(devPath string, speed int) (*Signer, error) {
+func NewSigner(devPath string, speed int, enterUSS bool, fileUSS string) (*Signer, error) {
 	mkdf.SilenceLogging()
 	le.Printf("Connecting to device on serial port %s ...\n", devPath)
 	tk, err := mkdf.New(devPath, speed)
 	if err != nil {
 		return nil, fmt.Errorf("Could not open %s: %w", devPath, err)
 	}
-	s := mkdfsign.New(tk)
-	signer := &Signer{
-		TillitisKey: &tk,
-		Signer:      &s,
-	}
-	if !signer.isWantedApp() {
-		if !signer.isFirmwareMode() {
-			// now we know that:
-			// - loaded app does not have the wanted name
-			// - device is not in firmware mode
-			// anything else is possible
-			return nil, ErrMaybeWrongDevice
+
+	mkdfSigner := mkdfsign.New(tk)
+	signer := &Signer{&tk, &mkdfSigner}
+
+	// Start handling signals here to catch abort during USS entering
+	handleSignals(func() {
+		if err := signer.disconnect(); err != nil {
+			le.Printf("%s\n", err)
 		}
-		le.Printf("Device is in firmware mode, loading app...\n")
-		if err := signer.loadApp(appBinary); err != nil {
-			return nil, err
+		os.Exit(1)
+	}, os.Interrupt, syscall.SIGTERM)
+
+	if err = signer.maybeLoadApp(enterUSS, fileUSS); err != nil {
+		// We're failing, clean up and return the more important error
+		if err2 := signer.disconnect(); err2 != nil {
+			le.Printf("%s\n", err2)
 		}
+		return nil, err
 	}
 	return signer, nil
 }
 
-func (s *Signer) disconnect() error {
-	if s.Signer == nil {
+func (s *Signer) maybeLoadApp(enterUSS bool, fileUSS string) error {
+	if s.isWantedApp() {
+		if enterUSS || fileUSS != "" {
+			le.Printf("App is already loaded, USS flags are ignored.\n")
+		}
 		return nil
+	} else if !s.isFirmwareMode() {
+		// now we know that:
+		// - loaded app does not have the wanted name
+		// - device is not in firmware mode
+		// anything else is possible
+		return ErrMaybeWrongDevice
 	}
-	if err := s.Signer.Close(); err != nil {
-		return fmt.Errorf("signer.Close: %w", err)
+
+	le.Printf("Device is in firmware mode.\n")
+	var err error
+	var secretPhrase []byte
+	if enterUSS {
+		secretPhrase, err = inputUSS()
+		if err != nil {
+			return err
+		}
+	} else if fileUSS != "" {
+		if fileUSS == "-" {
+			if secretPhrase, err = io.ReadAll(os.Stdin); err != nil {
+				return fmt.Errorf("Failed to read uss-file from stdin: %w", err)
+			}
+		} else if secretPhrase, err = os.ReadFile(fileUSS); err != nil {
+			return fmt.Errorf("Failed to read uss-file: %w", err)
+		}
+	}
+
+	if len(secretPhrase) > 0 {
+		le.Printf("Loading USS...\n")
+		if err = s.tk.LoadUSS(secretPhrase); err != nil {
+			return fmt.Errorf("tk.LoadUSS: %w", err)
+		}
+	}
+
+	le.Printf("Loading app...\n")
+	if err = s.tk.LoadApp(appBinary); err != nil {
+		return fmt.Errorf("LoadApp: %w", err)
 	}
 	return nil
 }
 
-func (s *Signer) isFirmwareMode() bool {
-	_, err := s.GetNameVersion()
-	return err == nil
+func (s *Signer) disconnect() error {
+	if s.mkdfSigner == nil {
+		return nil
+	}
+	if err := s.mkdfSigner.Close(); err != nil {
+		return fmt.Errorf("mkdfSigner.Close: %w", err)
+	}
+	return nil
 }
 
 func (s *Signer) isWantedApp() bool {
-	nameVer, err := s.Signer.GetAppNameVersion()
+	nameVer, err := s.mkdfSigner.GetAppNameVersion()
 	if err != nil {
 		if !errors.Is(err, io.EOF) {
 			le.Printf("GetAppNameVersion: %s\n", err)
@@ -91,17 +138,15 @@ func (s *Signer) isWantedApp() bool {
 	return true
 }
 
-func (s *Signer) loadApp(bin []byte) error {
-	if err := s.LoadApp(bin); err != nil {
-		return fmt.Errorf("LoadApp: %w", err)
-	}
-	return nil
+func (s *Signer) isFirmwareMode() bool {
+	_, err := s.tk.GetNameVersion()
+	return err == nil
 }
 
 // implementing crypto.Signer below
 
 func (s *Signer) Public() crypto.PublicKey {
-	pub, err := s.Signer.GetPubkey()
+	pub, err := s.mkdfSigner.GetPubkey()
 	if err != nil {
 		le.Printf("GetPubKey failed: %s\n", err)
 		return nil
@@ -116,9 +161,41 @@ func (s *Signer) Sign(rand io.Reader, message []byte, opts crypto.SignerOpts) ([
 		return nil, errors.New("message must not be hashed")
 	}
 
-	signature, err := s.Signer.Sign(message)
+	signature, err := s.mkdfSigner.Sign(message)
 	if err != nil {
 		return nil, fmt.Errorf("Sign: %w", err)
 	}
 	return signature, nil
+}
+
+func handleSignals(action func(), sig ...os.Signal) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, sig...)
+	go func() {
+		for {
+			<-ch
+			action()
+		}
+	}()
+}
+
+func inputUSS() ([]byte, error) {
+	fmt.Printf("Enter phrase for the USS: ")
+	uss, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return nil, fmt.Errorf("ReadPassword: %w", err)
+	}
+	fmt.Printf("\nRepeat the phrase: ")
+	ussAgain, err := term.ReadPassword(0)
+	if err != nil {
+		return nil, fmt.Errorf("ReadPassword: %w", err)
+	}
+	fmt.Printf("\n")
+	if bytes.Compare(uss, ussAgain) != 0 {
+		return nil, fmt.Errorf("phrases did not match")
+	}
+	if len(uss) == 0 {
+		return nil, fmt.Errorf("no phrase entered")
+	}
+	return uss, nil
 }

--- a/cmd/runapp/main.go
+++ b/cmd/runapp/main.go
@@ -4,25 +4,27 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/spf13/pflag"
+	"github.com/tillitis/tillitis-key1-apps/internal/uss"
 	"github.com/tillitis/tillitis-key1-apps/mkdf"
-	"golang.org/x/term"
 )
 
 func main() {
 	fileName := pflag.String("file", "", "App binary to be uploaded and started")
 	port := pflag.String("port", "/dev/ttyACM0", "Serial port path")
 	speed := pflag.Int("speed", 38400, "When talking over the serial port, bits per second")
-	typeUSS := pflag.Bool("uss", false, "Enable typing of a phrase for the User Supplied Secret. The phrase\n"+
+	enterUSS := pflag.Bool("uss", false, "Enable typing of a phrase for the User Supplied Secret. The phrase\n"+
 		"is hashed using BLAKE2 to a digest. The USS digest is used by the\n"+
 		"firmware, together with other material, for deriving secrets for the\n"+
 		"application.")
+	fileUSS := pflag.String("uss-file", "", "Read a file and hash its contents as the USS. Use --uss-file=-\n"+
+		"for reading from stdin. Note that the all data in file/stdin is\n"+
+		"hashed, newlines are not stripped.")
 	verbose := pflag.Bool("verbose", false, "Enable verbose output")
 	pflag.Parse()
 
@@ -32,6 +34,12 @@ func main() {
 
 	if *fileName == "" {
 		fmt.Printf("Please pass at least --file\n")
+		pflag.Usage()
+		os.Exit(2)
+	}
+
+	if *enterUSS && *fileUSS != "" {
+		fmt.Printf("Can't combine --uss and --uss-file\n\n")
 		pflag.Usage()
 		os.Exit(2)
 	}
@@ -61,14 +69,24 @@ func main() {
 	fmt.Printf("Firmware has name0:%s name1:%s version:%d\n",
 		nameVer.Name0, nameVer.Name1, nameVer.Version)
 
-	if *typeUSS {
-		uss, err := inputUSS()
+	var secret []byte
+	if *enterUSS {
+		secret, err = uss.InputUSS()
 		if err != nil {
-			fmt.Printf("Failed: %v\n", err)
+			fmt.Printf("Failed to get USS: %v\n", err)
 			exit(1)
 		}
+	} else if *fileUSS != "" {
+		secret, err = uss.ReadUSS(*fileUSS)
+		if err != nil {
+			fmt.Printf("Failed to read uss-file %s: %v", *fileUSS, err)
+			exit(1)
+		}
+	}
+
+	if len(secret) > 0 {
 		fmt.Printf("Loading USS onto device\n")
-		if err = tk.LoadUSS(uss); err != nil {
+		if err = tk.LoadUSS(secret); err != nil {
 			fmt.Printf("LoadUSS failed: %v\n", err)
 			exit(1)
 		}
@@ -93,25 +111,4 @@ func handleSignals(action func(), sig ...os.Signal) {
 			action()
 		}
 	}()
-}
-
-func inputUSS() ([]byte, error) {
-	fmt.Printf("Enter phrase for the USS: ")
-	uss, err := term.ReadPassword(int(os.Stdin.Fd()))
-	if err != nil {
-		return nil, fmt.Errorf("ReadPassword: %w", err)
-	}
-	fmt.Printf("\nRepeat the phrase: ")
-	ussAgain, err := term.ReadPassword(0)
-	if err != nil {
-		return nil, fmt.Errorf("ReadPassword: %w", err)
-	}
-	fmt.Printf("\n")
-	if bytes.Compare(uss, ussAgain) != 0 {
-		return nil, fmt.Errorf("phrases did not match")
-	}
-	if len(uss) == 0 {
-		return nil, fmt.Errorf("no phrase entered")
-	}
-	return uss, nil
 }

--- a/cmd/tk1sign/main.go
+++ b/cmd/tk1sign/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func main() {
-	fileName := pflag.String("file", "", "Name of file with data to be signed")
+	fileName := pflag.String("file", "", "Name of file with data to be signed (the \"message\")")
 	port := pflag.String("port", "/dev/ttyACM0", "Serial port path")
 	speed := pflag.Int("speed", 38400, "When talking over the serial port, bits per second")
 	verbose := pflag.Bool("verbose", false, "Enable verbose output")
@@ -24,6 +24,12 @@ func main() {
 
 	if !*verbose {
 		mkdf.SilenceLogging()
+	}
+
+	if *fileName == "" {
+		fmt.Printf("Please pass at least --file\n")
+		pflag.Usage()
+		os.Exit(2)
 	}
 
 	message, err := os.ReadFile(*fileName)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	go.bug.st/serial v1.4.0
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 )
 
 require (

--- a/internal/uss/uss.go
+++ b/internal/uss/uss.go
@@ -1,0 +1,44 @@
+package uss
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+func InputUSS() ([]byte, error) {
+	fmt.Printf("Enter phrase for the USS: ")
+	secret, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return nil, fmt.Errorf("ReadPassword: %w", err)
+	}
+	fmt.Printf("\nRepeat the phrase: ")
+	ussAgain, err := term.ReadPassword(0)
+	if err != nil {
+		return nil, fmt.Errorf("ReadPassword: %w", err)
+	}
+	fmt.Printf("\n")
+	if bytes.Compare(secret, ussAgain) != 0 {
+		return nil, fmt.Errorf("phrases did not match")
+	}
+	if len(secret) == 0 {
+		return nil, fmt.Errorf("no phrase entered")
+	}
+	return secret, nil
+}
+
+func ReadUSS(fileUSS string) ([]byte, error) {
+	var secret []byte
+	var err error
+	if fileUSS == "-" {
+		if secret, err = io.ReadAll(os.Stdin); err != nil {
+			return nil, fmt.Errorf("ReadAll: %w", err)
+		}
+	} else if secret, err = os.ReadFile(fileUSS); err != nil {
+		return nil, fmt.Errorf("ReadFile: %w", err)
+	}
+	return secret, nil
+}

--- a/mkdf/proto.go
+++ b/mkdf/proto.go
@@ -61,7 +61,9 @@ var (
 	cmdRunApp         = fwCmd{0x07, "cmdRunApp", CmdLen1}
 	rspRunApp         = fwCmd{0x08, "rspRunApp", CmdLen4}
 	cmdGetAppDigest   = fwCmd{0x09, "cmdGetAppDigest", CmdLen1}
-	rspGetAppDigest   = fwCmd{0x10, "rspGetAppDigest", CmdLen128}
+	rspGetAppDigest   = fwCmd{0x10, "rspGetAppDigest", CmdLen128} // encoded as 0x10 by typo
+	cmdLoadUSS        = fwCmd{0x0a, "cmdLoadUSS", CmdLen128}
+	rspLoadUSS        = fwCmd{0x0b, "rspLoadUSS", CmdLen4}
 )
 
 type fwCmd struct {


### PR DESCRIPTION
Ref fw issue tillitis/tillitis-key1#2 and PR https://github.com/tillitis/tillitis-key1/pull/9

See in code comments, copypasted here:
```
     // TODO
     //
     // The (user input string for the) secret USS should probably not be passed
     // as a cmdline arg. So ask user to to type it then? Can also read it from
     // file passed on cmdline, with classic "-" meaning stdin.
     //
     // But how to make this usable in mkdf-ssh-agent?
     //
     // Do users need to understand that the string they input (by some means)
     // is not used directly, but is hashed to become the USS (32 bytes)?
     //
```