### PR TITLE
Make LoadApp() take USS

### DIFF
--- a/cmd/mkdf-ssh-agent/signer.go
+++ b/cmd/mkdf-ssh-agent/signer.go
@@ -95,15 +95,8 @@ func (s *Signer) maybeLoadApp(enterUSS bool, fileUSS string) error {
 		}
 	}
 
-	if len(secret) > 0 {
-		le.Printf("Loading USS...\n")
-		if err = s.tk.LoadUSS(secret); err != nil {
-			return fmt.Errorf("tk.LoadUSS: %w", err)
-		}
-	}
-
 	le.Printf("Loading app...\n")
-	if err = s.tk.LoadApp(appBinary); err != nil {
+	if err = s.tk.LoadApp(appBinary, secret); err != nil {
 		return fmt.Errorf("LoadApp: %w", err)
 	}
 	return nil

--- a/cmd/runapp/main.go
+++ b/cmd/runapp/main.go
@@ -84,16 +84,8 @@ func main() {
 		}
 	}
 
-	if len(secret) > 0 {
-		fmt.Printf("Loading USS onto device\n")
-		if err = tk.LoadUSS(secret); err != nil {
-			fmt.Printf("LoadUSS failed: %v\n", err)
-			exit(1)
-		}
-	}
-
 	fmt.Printf("Loading app from %v onto device\n", *fileName)
-	err = tk.LoadAppFromFile(*fileName)
+	err = tk.LoadAppFromFile(*fileName, secret)
 	if err != nil {
 		fmt.Printf("LoadAppFromFile failed: %v\n", err)
 		exit(1)

--- a/mkdf/mkdf.go
+++ b/mkdf/mkdf.go
@@ -119,7 +119,7 @@ func (tk TillitisKey) GetNameVersion() (*NameVersion, error) {
 		return nil, err
 	}
 
-	_, rx, err := tk.ReadFrame(rspGetNameVersion, id)
+	rx, _, err := tk.ReadFrame(rspGetNameVersion, id)
 	if err != nil {
 		return nil, fmt.Errorf("ReadFrame: %w", err)
 	}
@@ -129,7 +129,7 @@ func (tk TillitisKey) GetNameVersion() (*NameVersion, error) {
 	}
 
 	nameVer := &NameVersion{}
-	nameVer.Unpack(rx[1:])
+	nameVer.Unpack(rx[2:])
 
 	return nameVer, nil
 }
@@ -156,12 +156,12 @@ func (tk TillitisKey) LoadUSS(secretPhrase []byte) error {
 		return err
 	}
 
-	_, rx, err := tk.ReadFrame(rspLoadUSS, id)
+	rx, _, err := tk.ReadFrame(rspLoadUSS, id)
 	if err != nil {
 		return fmt.Errorf("ReadFrame: %w", err)
 	}
 
-	if rx[1] != StatusOK {
+	if rx[2] != StatusOK {
 		return fmt.Errorf("LoadUSS NOK")
 	}
 
@@ -247,12 +247,12 @@ func (tk TillitisKey) setAppSize(size int) error {
 		return err
 	}
 
-	_, rx, err := tk.ReadFrame(rspLoadAppSize, id)
+	rx, _, err := tk.ReadFrame(rspLoadAppSize, id)
 	if err != nil {
 		return fmt.Errorf("ReadFrame: %w", err)
 	}
 
-	if rx[1] != StatusOK {
+	if rx[2] != StatusOK {
 		return fmt.Errorf("SetAppSize NOK")
 	}
 
@@ -286,12 +286,12 @@ func (tk TillitisKey) loadAppData(content []byte) (int, error) {
 	}
 
 	// Wait for reply
-	_, rx, err := tk.ReadFrame(rspLoadAppData, id)
+	rx, _, err := tk.ReadFrame(rspLoadAppData, id)
 	if err != nil {
 		return 0, fmt.Errorf("ReadFrame: %w", err)
 	}
 
-	if rx[1] != StatusOK {
+	if rx[2] != StatusOK {
 		return 0, fmt.Errorf("LoadAppData NOK")
 	}
 
@@ -314,12 +314,12 @@ func (tk TillitisKey) getAppDigest() ([32]byte, error) {
 	}
 
 	// Wait for reply
-	_, rx, err := tk.ReadFrame(rspGetAppDigest, id)
+	rx, _, err := tk.ReadFrame(rspGetAppDigest, id)
 	if err != nil {
 		return md, fmt.Errorf("ReadFrame: %w", err)
 	}
 
-	copy(md[:], rx[1:])
+	copy(md[:], rx[2:])
 
 	return md, nil
 }
@@ -337,12 +337,12 @@ func (tk TillitisKey) runApp() error {
 	}
 
 	// Wait for reply
-	_, rx, err := tk.ReadFrame(rspRunApp, id)
+	rx, _, err := tk.ReadFrame(rspRunApp, id)
 	if err != nil {
 		return fmt.Errorf("ReadFrame: %w", err)
 	}
 
-	if rx[1] != StatusOK {
+	if rx[2] != StatusOK {
 		return fmt.Errorf("RunApp NOK")
 	}
 

--- a/mkdfsign/mkdfsign.go
+++ b/mkdfsign/mkdfsign.go
@@ -103,7 +103,7 @@ func (s Signer) GetAppNameVersion() (*mkdf.NameVersion, error) {
 		return nil, fmt.Errorf("SetReadTimeout: %w", err)
 	}
 
-	_, rx, err := s.tk.ReadFrame(rspGetNameVersion, id)
+	rx, _, err := s.tk.ReadFrame(rspGetNameVersion, id)
 	if err != nil {
 		return nil, fmt.Errorf("ReadFrame: %w", err)
 	}
@@ -114,7 +114,7 @@ func (s Signer) GetAppNameVersion() (*mkdf.NameVersion, error) {
 	}
 
 	nameVer := &mkdf.NameVersion{}
-	nameVer.Unpack(rx[1:])
+	nameVer.Unpack(rx[2:])
 
 	return nameVer, nil
 }
@@ -132,14 +132,14 @@ func (s Signer) GetPubkey() ([]byte, error) {
 		return nil, fmt.Errorf("Write: %w", err)
 	}
 
-	_, rx, err := s.tk.ReadFrame(rspGetPubkey, id)
+	rx, _, err := s.tk.ReadFrame(rspGetPubkey, id)
 	mkdf.Dump("GetPubKey rx", rx)
 	if err != nil {
 		return nil, fmt.Errorf("ReadFrame: %w", err)
 	}
 
 	// Skip frame header & app header, returning size of ed25519 pubkey
-	return rx[1 : 1+32], nil
+	return rx[2 : 2+32], nil
 }
 
 // Sign signs the message in data and returns an ed25519 signature.
@@ -186,13 +186,13 @@ func (s Signer) setSize(size int) error {
 		return fmt.Errorf("Write: %w", err)
 	}
 
-	_, rx, err := s.tk.ReadFrame(rspSetSize, id)
+	rx, _, err := s.tk.ReadFrame(rspSetSize, id)
 	mkdf.Dump("SetAppSize rx", rx)
 	if err != nil {
 		return fmt.Errorf("ReadFrame: %w", err)
 	}
 
-	if rx[1] != mkdf.StatusOK {
+	if rx[2] != mkdf.StatusOK {
 		return fmt.Errorf("SetSignSize NOK")
 	}
 
@@ -225,12 +225,12 @@ func (s Signer) signLoad(content []byte) (int, error) {
 	}
 
 	// Wait for reply
-	_, rx, err := s.tk.ReadFrame(rspSignData, id)
+	rx, _, err := s.tk.ReadFrame(rspSignData, id)
 	if err != nil {
 		return 0, fmt.Errorf("ReadFrame: %w", err)
 	}
 
-	if rx[1] != mkdf.StatusOK {
+	if rx[2] != mkdf.StatusOK {
 		return 0, fmt.Errorf("SignData NOK")
 	}
 
@@ -251,11 +251,11 @@ func (s Signer) getSig() ([]byte, error) {
 		return nil, fmt.Errorf("Write: %w", err)
 	}
 
-	_, rx, err := s.tk.ReadFrame(rspGetSig, id)
+	rx, _, err := s.tk.ReadFrame(rspGetSig, id)
 	if err != nil {
 		return nil, fmt.Errorf("ReadFrame: %w", err)
 	}
 
-	// Skip app header, returning size of ed25519 signature
-	return rx[1 : 1+64], nil
+	// Skip frame header & app header, returning size of ed25519 signature
+	return rx[2 : 2+64], nil
 }


### PR DESCRIPTION
To reinforce the need for doing LOAD_USS.

The first commit corrects the Dump()ing of a received frame, by letting ReadFrame() return the whole frame read (including header byte) (it's another take on `correct-rx-dump`).

See also: https://github.com/tillitis/tillitis-key1/pull/20
