### PR TITLE
Fix a couple of signerapp protocol inconsistencies...

### DIFF
--- a/apps/signerapp/main.c
+++ b/apps/signerapp/main.c
@@ -109,9 +109,10 @@ int main(void)
 
 		case APP_CMD_SET_SIZE:
 			puts("APP_CMD_SET_SIZE\n");
+			// Bad length
 			if (hdr.len != 32) {
-				// Bad length
-				puts("APP_CMD_SET_SIZE bad length\n");
+				rsp[0] = STATUS_BAD;
+				appreply(hdr, APP_RSP_SET_SIZE, rsp);
 				break;
 			}
 			signature_done = 0;
@@ -180,7 +181,8 @@ int main(void)
 				appreply(hdr, APP_RSP_GET_SIG, rsp);
 				break;
 			}
-			memcpy(rsp, signature, 64);
+			rsp[0] = STATUS_OK;
+			memcpy(rsp + 1, signature, 64);
 			appreply(hdr, APP_RSP_GET_SIG, rsp);
 			led_steady = LED_GREEN;
 			break;

--- a/tk1sign/tk1sign.go
+++ b/tk1sign/tk1sign.go
@@ -256,6 +256,11 @@ func (s Signer) getSig() ([]byte, error) {
 		return nil, fmt.Errorf("ReadFrame: %w", err)
 	}
 
-	// Skip frame header & app header, returning size of ed25519 signature
-	return rx[2 : 2+64], nil
+	if rx[2] != mkdf.StatusOK {
+		return nil, fmt.Errorf("getSig NOK")
+	}
+
+	// Skip frame header, app header, and status; returning size of
+	// ed25519 signature
+	return rx[3 : 3+64], nil
 }


### PR DESCRIPTION
- Make SET_SIZE reply also on cmd length error
- Make GET_SIG's replies always include status