### PR TITLE
Use -p, don't take over -k (used by OpenSSH ssh-agent for killing it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ interfere with this test.
 The tkey-ssh-agent also supports the `--uss` and `--uss-file` flags,
 as described for `tkey-runapp` above.
 
-You can use `-k` (long option: `--show-pubkey`) to only output the
+You can use `--show-pubkey` (short flag: `-p`) to only output the
 pubkey. The pubkey is printed to stdout for easy redirection, but some
 messages are still present on stderr.
 

--- a/cmd/tkey-sign/main.go
+++ b/cmd/tkey-sign/main.go
@@ -31,7 +31,7 @@ func main() {
 	var showPubkeyOnly, verbose, helpOnly bool
 	pflag.CommandLine.SetOutput(os.Stderr)
 	pflag.CommandLine.SortFlags = false
-	pflag.BoolVarP(&showPubkeyOnly, "show-pubkey", "k", false,
+	pflag.BoolVarP(&showPubkeyOnly, "show-pubkey", "p", false,
 		"Don't sign anything, only output the public key.")
 	pflag.StringVar(&devPath, "port", "",
 		"Set serial port device `PATH`. If this is not passed, auto-detection will be attempted.")
@@ -70,13 +70,13 @@ public key of the signer app on the TKey.`, os.Args[0])
 	}
 
 	if fileName == "" && !showPubkeyOnly {
-		le.Printf("Please pass at least a message FILE, or -k.\n\n")
+		le.Printf("Please pass at least a message FILE, or -p.\n\n")
 		pflag.Usage()
 		os.Exit(2)
 	}
 
 	if fileName != "" && showPubkeyOnly {
-		le.Printf("Pass only a message FILE or -k.\n\n")
+		le.Printf("Pass only a message FILE or -p.\n\n")
 		pflag.Usage()
 		os.Exit(2)
 	}

--- a/cmd/tkey-ssh-agent/main.go
+++ b/cmd/tkey-ssh-agent/main.go
@@ -43,7 +43,7 @@ func main() {
 	pflag.CommandLine.SortFlags = false
 	pflag.StringVarP(&sockPath, "agent-socket", "a", "",
 		"Start the agent, setting the `PATH` to the UNIX-domain socket that it should bind/listen to.")
-	pflag.BoolVarP(&showPubkeyOnly, "show-pubkey", "k", false,
+	pflag.BoolVarP(&showPubkeyOnly, "show-pubkey", "p", false,
 		"Don't start the agent, only output the ssh-ed25519 public key.")
 	pflag.BoolVarP(&listPortsOnly, "list-ports", "L", false,
 		"List possible serial ports to use with --port.")
@@ -60,7 +60,7 @@ func main() {
 	pflag.BoolVar(&versionOnly, "version", false, "Output version information.")
 	pflag.BoolVar(&helpOnly, "help", false, "Output this help.")
 	pflag.Usage = func() {
-		desc := fmt.Sprintf(`Usage: %[1]s -a|-k|-L [flags...]
+		desc := fmt.Sprintf(`Usage: %[1]s -a|-p|-L [flags...]
 
 %[1]s is an alternative SSH agent that communicates with a Tillitis TKey
 USB stick. This stick holds private key and signing functionality for public key
@@ -108,7 +108,7 @@ green when the stick must be touched to complete a signature.`, progname)
 		exclusive++
 	}
 	if exclusive > 1 {
-		le.Printf("Pass only one of -a, -k, or -L.\n\n")
+		le.Printf("Pass only one of -a, -p, or -L.\n\n")
 		pflag.Usage()
 		exit(2)
 	}
@@ -126,7 +126,7 @@ green when the stick must be touched to complete a signature.`, progname)
 	}
 
 	if !showPubkeyOnly && sockPath == "" {
-		le.Printf("Please pass at least -a or -k.\n\n")
+		le.Printf("Please pass at least -a or -p.\n\n")
 		pflag.Usage()
 		exit(2)
 	}


### PR DESCRIPTION
Signed-off-by: Daniel Lublin <daniel@lublin.se>